### PR TITLE
Make the # before members and methods a clickable anchor

### DIFF
--- a/static/styles/clean-jsdoc-theme-dark.css
+++ b/static/styles/clean-jsdoc-theme-dark.css
@@ -128,7 +128,8 @@ footer {
     color: #00918e;
 }
 
-.name {
+.name,
+.name a {
     color: #f7f7f7;
 }
 

--- a/static/styles/clean-jsdoc-theme-light.css
+++ b/static/styles/clean-jsdoc-theme-light.css
@@ -140,7 +140,8 @@ footer {
     color: #00918e;
 }
 
-.name {
+.name,
+.name a {
     color: #293a80;
 }
 

--- a/static/styles/jsdoc-default.css
+++ b/static/styles/jsdoc-default.css
@@ -397,13 +397,10 @@ footer {
     font-weight: bold;
 }
 
-/* stylelint-disable */
-h4.name::before {
-    content: '# ';
+.name a {
     font-size: 28px;
 }
 
-/* stylelint-enable */
 
 .details {
     margin: 0;

--- a/tmpl/members.tmpl
+++ b/tmpl/members.tmpl
@@ -2,7 +2,10 @@
 var data = obj;
 var self = this;
 ?>
-<h4 class="name" id="<?js= id ?>"><?js= data.attribs + name + (data.signature ? data.signature : '') ?></h4>
+<h4 class="name" id="<?js= id ?>">
+    <a href="#<?js= id ?>">#</a>
+    <?js= data.attribs + name + (data.signature ? data.signature : '') ?>
+</h4>
 
 <?js if (data.summary) { ?>
 <p class="summary"><?js= summary ?></p>

--- a/tmpl/method.tmpl
+++ b/tmpl/method.tmpl
@@ -7,8 +7,10 @@ var self = this;
         <h2>Constructor</h2>
     <?js } ?>
 
-    <h4 class="name" id="<?js= id ?>"><?js= data.attribs + (kind === 'class' ? 'new ' : '') +
-    name + (data.signature || '') ?></h4>
+    <h4 class="name" id="<?js= id ?>">
+        <a href="#<?js= id ?>">#</a>
+        <?js= data.attribs + (kind === 'class' ? 'new ' : '') + name + (data.signature || '') ?>
+    </h4>
 
     <?js if (data.summary) { ?>
         <p class="summary"><?js= summary ?></p>
@@ -113,10 +115,10 @@ var self = this;
                     <li><?js= self.partial('returns.tmpl', r) ?></li>
                 <?js }); ?>
             </ul>
-        
+
         <?js } else { returns.forEach(function(r) { ?>
             <?js= self.partial('returns.tmpl', r) ?><?js });
-        } ?> 
+        } ?>
     </div>
 <?js } ?>
 


### PR DESCRIPTION
# Pull Request Template

## Description

The `#` in front of members and methods is now a link to the anchor in the page. This allow users to share permalink to the specific position in the page.

## Type of change

Please mark options that is/are relevant.
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Other (if so, then explain below briefly)
