### PR TITLE
See support

### DIFF
--- a/tmpl/container.tmpl
+++ b/tmpl/container.tmpl
@@ -65,20 +65,14 @@
             <div class="description"><?js= doc.description ?></div>
         <?js } ?>
 
-        <?js if(doc.source) { ?>
-            <?js= self.partial('details.tmpl', doc) ?>
-        <?js } ?>
+        <?js= self.partial('details.tmpl', doc) ?>
+
         <?js if (doc.examples && doc.examples.length) { ?>
             <h3>Example<?js= doc.examples.length > 1? 's':'' ?></h3>
             <?js= self.partial('examples.tmpl', doc.examples) ?>
         <?js } ?>
     <?js } ?>
     </div>
-
-    <?js if (doc.see) { ?>
-        <h3 class="subsection-title">See:</h3>
-        <p><?js= doc.see ?></p>
-    <?js } ?>
 
     <?js if (doc.augments && doc.augments.length) { ?>
         <h3 class="subsection-title">Extends</h3>

--- a/tmpl/container.tmpl
+++ b/tmpl/container.tmpl
@@ -72,6 +72,12 @@
             <h3>Example<?js= doc.examples.length > 1? 's':'' ?></h3>
             <?js= self.partial('examples.tmpl', doc.examples) ?>
         <?js } ?>
+
+
+        <?js if (doc.see) { ?>
+            <h3 class="subsection-title">See:</h3>
+            <p><?js= doc.see ?></p>
+        <?js } ?>
     <?js } ?>
     </div>
 

--- a/tmpl/container.tmpl
+++ b/tmpl/container.tmpl
@@ -72,14 +72,13 @@
             <h3>Example<?js= doc.examples.length > 1? 's':'' ?></h3>
             <?js= self.partial('examples.tmpl', doc.examples) ?>
         <?js } ?>
-
-
-        <?js if (doc.see) { ?>
-            <h3 class="subsection-title">See:</h3>
-            <p><?js= doc.see ?></p>
-        <?js } ?>
     <?js } ?>
     </div>
+
+    <?js if (doc.see) { ?>
+        <h3 class="subsection-title">See:</h3>
+        <p><?js= doc.see ?></p>
+    <?js } ?>
 
     <?js if (doc.augments && doc.augments.length) { ?>
         <h3 class="subsection-title">Extends</h3>


### PR DESCRIPTION
## Description

Added conditional block for `@see` display on `container.tmpl`

With the addition of this conditional block the container template will now correctly display `@see` tags.
```
/**
 * ...
 * @see {@link http://link.to.resource|Link Display Text}
 * ...
 */
```
Reference: https://jsdoc.app/tags-see.html

Before
![image](https://user-images.githubusercontent.com/5934577/108505898-12b57c80-7286-11eb-8b30-49394818b895.png)

After:
![image](https://user-images.githubusercontent.com/5934577/108512633-814b0800-728f-11eb-8930-e543e9fc4403.png)


Fixes #58 

## Type of change

Please mark options that is/are relevant.
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Other (if so, then explain below briefly)
