### PR TITLE
fix unclosed <div> in method.tmpl

### DIFF
--- a/tmpl/method.tmpl
+++ b/tmpl/method.tmpl
@@ -113,7 +113,7 @@ var self = this;
     <?js } else { exceptions.forEach(function(r) { ?>
         <?js= self.partial('exceptions.tmpl', r) ?>
     <?js });} ?>
-    <div>
+    </div>
 <?js } ?>
 
 <?js if (data.returns && returns.length) { ?>


### PR DESCRIPTION
## Description

b1ec5d02d070f27db1c95c0e8643e73f29fa411f introduced a [malformed closing tag][] in `method.tmpl`.

Using the [Pair Tag Highlighter for Geany][], the incomplete element looked like this:

![Screenshot_2021-03-28_21-49-24](https://user-images.githubusercontent.com/59004801/112779368-234fd400-9036-11eb-8971-725792393a78.png)

This patch corrects the markup:

![Screenshot_2021-03-28_21-50-02](https://user-images.githubusercontent.com/59004801/112779425-3b275800-9036-11eb-8cf0-a6d8b337a89a.png)
 
## Type of change

Please mark options that is/are relevant.
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Other (if so, then explain below briefly)

[malformed closing tag]: https://github.com/ankitskvmdam/clean-jsdoc-theme/commit/b1ec5d02d070f27db1c95c0e8643e73f29fa411f#diff-881ef6669f98fc684032111c45a737846c593a95a198ea4e1ae342b31a608308R115-R117

[Pair Tag Highlighter for Geany]: https://github.com/geany/geany-plugins/tree/master/pairtaghighlighter#readme