### PR TITLE
add menuLocation option to adjust the place to append extra links

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,10 @@ This options allows rendering of extra link(s) in navbar to the side of the docu
 | `class`  | `string` |
 | `id`     | `string` |
 
+### `menuLocation: "up" | "down"`
+
+This options allows to adjust the location of the menu items listed in `menu` array, either at the top or at the bottom among all navbar items. `Default value is "up".`
+
 ### `meta: Array<{}>`
 
 A list of `meta` tag attributes to add to the `head` of each page.

--- a/publish.js
+++ b/publish.js
@@ -615,9 +615,10 @@ function buildNav(members) {
     var seenTutorials = {};
 
     var menu = (themeOpts.menu) || undefined;
+    var menuLocation = themeOpts.menuLocation || 'up';
 
 
-    if (menu !== undefined) { nav += buildMenuNav(menu); }
+    if (menu !== undefined && menuLocation === 'up') { nav += buildMenuNav(menu); }
     nav += buildMemberNav(members.tutorials, 'Tutorials', seenTutorials, linktoTutorial, true);
     nav += buildMemberNav(members.classes, 'Classes', seen, linkto);
     nav += buildMemberNav(members.modules, 'Modules', {}, linkto);
@@ -627,7 +628,7 @@ function buildNav(members) {
     nav += buildMemberNav(members.mixins, 'Mixins', seen, linkto);
     nav += buildMemberNav(members.interfaces, 'Interfaces', seen, linkto);
     nav += buildMemberNav(members.globals, 'Global', seen, linkto);
-
+    if (menu !== undefined && menuLocation === 'down') { nav += buildMenuNav(menu); }
     nav += '</div>';
 
     return nav;


### PR DESCRIPTION
# Pull Request Template

## Description

Add an additional option called menuLocation, which accepts "up" or "down" as input so that the extra links can be placed at either top or bottom of the navbar.

Fixes #77 

## Type of change

Please mark options that is/are relevant.
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Other (if so, then explain below briefly)
