### PR TITLE
Fixed the search condition statement

### DIFF
--- a/tmpl/layout.tmpl
+++ b/tmpl/layout.tmpl
@@ -122,7 +122,7 @@
     <script src="scripts/linenumber.js"></script>
     <script src="scripts/fix-code-block.js"></script>
     <script src="scripts/fix-navbar.js"></script>
-    <?js if(!Boolean(this.search.options)) { ?>
+    <?js if(this.search.options !== 'false') { ?>
       <script src="scripts/search.js"></script>
       <script src="scripts/third-party/fuse.js"></script>
       <script>


### PR DESCRIPTION
## Description
As it stands, the behavior is that if the search obj is absent, it will pass. However, if any value is given, including false, { searchOptions }, etc... it will not load the libraries.

Solved the condition related to importing the fuse.js and search functionalities from working due to incorrect usage of the Boolean(). 
See [Documentation Description](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean#description).

## Solution
Re-write the condition to be options !== 'false', since as dictated, any value should load these libraries unless explicitly given a false value.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Other (if so, then explain below briefly)
