### PR TITLE
Remove duplicate usage of dynamicScript and fix doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,7 +305,7 @@ Here the nav and footer style rule is to attached to the HTML's `style` tag.
 To create custom scripts. Example:
 
 ```json
-"create_style": "function foo(){console.log('foo')} function bar() {console.log('bar')}"
+"add_scripts": "function foo(){console.log('foo')} function bar() {console.log('bar')}"
 ```
 
 Here the script is to attached to the HTML's `script` tag.

--- a/tmpl/layout.tmpl
+++ b/tmpl/layout.tmpl
@@ -150,12 +150,6 @@
       </script>
     <?js } ?>
 
-    <?js if(this.dynamicScript != undefined ) { ?>
-    <script type="text/javascript">
-    <?js= this.dynamicScript ?>
-    </script>
-    <?js } ?>
-
     <?js if(this.overlayScrollbar != undefined ) { ?>
     <script type="text/javascript">
     var option = JSON.parse('<?js=this.overlayScrollbar ?>')


### PR DESCRIPTION
# Pull Request Template

## Description

Remove duplicated usage of `dynamicScript` in the layout

Fixes # (issue)

## Type of change

Please mark options that is/are relevant.
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

I can also see that `dynamicScript` is positioned at the end of the page. Would it be possible to set one right after the the `dynamicScriptSrc` ? My typical use case is about adding googletagmanager to my documentation.

Thank you for your amazing work btw