### PR TITLE
Add exclude_inherited option

### DIFF
--- a/README.md
+++ b/README.md
@@ -397,6 +397,16 @@ To include js files. Example:
 
 It will include the js files to the output dir and also attach a script tag to the html pointing to the included js file.
 
+### `exclude_inherited: <boolean>`
+
+To exclude inherited symbols. Example:
+
+```json
+"exclude_inherited": true
+```
+
+This will remove all symbols (members, methods ...) that come from inherited parents.
+
 ### Example `theme_opts`
 
 ```json
@@ -454,6 +464,8 @@ It will include the js files to the output dir and also attach a script tag to t
     "include_css": ["./static/index.css", "./src/docs/index.css"],
     "include_js": ["./static/main.js", "./third-party/test/index.js"],
 
+    "exclude_inherited": true,
+
     "overlay_scrollbar": {
         "options": {
         }
@@ -494,6 +506,7 @@ It will include the js files to the output dir and also attach a script tag to t
 | `static_dir`        | `null`                                                                                                               | To include static dir                                                      | Array of string           |
 | `include_css`       | `null`                                                                                                               | To include css files                                                       | Array of string           |
 | `include_js`        | `null`                                                                                                               | To include js files                                                        | `string`                  |
+| `exclude_inherited` | `false`                                                                                                              | To exclude inherited symbols                                               | `boolean`                 |
 | `overlay_scrollbar` | `null`                                                                                                               | To use overlay scrollbar                                                   | Overlay Scrollbar options |
 | `sections`          | `["Menu", "Modules", "Classes", "Externals", "Events", "Namespaces", "Mixins", "Tutorials", "Interfaces", "Global"]` | To order navbar/sidebar sections or to hide/remove navbar/sidebar sections | `Array<SECTION_TYPE>`     |
 

--- a/publish.js
+++ b/publish.js
@@ -1051,6 +1051,7 @@ exports.publish = function(taffyData, opts, tutorials) {
     view.search = search();
     view.resizeable = resizeable();
     view.codepen = codepen();
+    view.excludeInherited = Boolean(themeOpts.exclude_inherited);
     attachModuleSymbols(
         find({ longname: { left: 'module:' } }),
         members.modules

--- a/tmpl/container.tmpl
+++ b/tmpl/container.tmpl
@@ -87,7 +87,7 @@
     <?js } ?>
 
     <?js
-        var classes = self.find({kind: 'class', memberof: doc.longname});
+        var classes = self.find({kind: 'class', memberof: doc.longname, inherited: {'!is': self.excludeInherited}});
         if (!isGlobalPage && classes && classes.length) {
     ?>
         <h3 class="subsection-title">Classes</h3>
@@ -99,7 +99,7 @@
     <?js } ?>
 
      <?js
-        var mixins = self.find({kind: 'mixin', memberof: doc.longname});
+        var mixins = self.find({kind: 'mixin', memberof: doc.longname, inherited: {'!is': self.excludeInherited}});
         if (!isGlobalPage && mixins && mixins.length) {
     ?>
         <h3 class="subsection-title">Mixins</h3>
@@ -111,7 +111,7 @@
     <?js } ?>
 
     <?js
-        var namespaces = self.find({kind: 'namespace', memberof: doc.longname});
+        var namespaces = self.find({kind: 'namespace', memberof: doc.longname, inherited: {'!is': self.excludeInherited}});
         if (!isGlobalPage && namespaces && namespaces.length) {
     ?>
         <h3 class="subsection-title">Namespaces</h3>
@@ -123,7 +123,7 @@
     <?js } ?>
 
     <?js
-        var members = self.find({kind: 'member', memberof: isGlobalPage ? {isUndefined: true} : doc.longname});
+        var members = self.find({kind: 'member', memberof: isGlobalPage ? {isUndefined: true} : doc.longname, inherited: {'!is': self.excludeInherited}});
 
         // symbols that are assigned to module.exports are not globals, even though they're not a memberof anything
         if (isGlobalPage && members && members.length && members.forEach) {
@@ -141,7 +141,7 @@
     <?js } ?>
 
     <?js
-        var methods = self.find({kind: 'function', memberof: isGlobalPage ? {isUndefined: true} : doc.longname});
+        var methods = self.find({kind: 'function', memberof: isGlobalPage ? {isUndefined: true} : doc.longname, inherited: {'!is': self.excludeInherited}});
         if (methods && methods.length && methods.forEach) {
     ?>
         <h3 class="subsection-title">Methods</h3>
@@ -152,7 +152,7 @@
     <?js } ?>
 
     <?js
-        var typedefs = self.find({kind: 'typedef', memberof: isGlobalPage ? {isUndefined: true} : doc.longname});
+        var typedefs = self.find({kind: 'typedef', memberof: isGlobalPage ? {isUndefined: true} : doc.longname, inherited: {'!is': self.excludeInherited}});
         if (typedefs && typedefs.length && typedefs.forEach) {
     ?>
         <h3 class="subsection-title">Type Definitions</h3>
@@ -172,7 +172,7 @@
     <?js } ?>
 
     <?js
-        var events = self.find({kind: 'event', memberof: isGlobalPage ? {isUndefined: true} : doc.longname});
+        var events = self.find({kind: 'event', memberof: isGlobalPage ? {isUndefined: true} : doc.longname, inherited: {'!is': self.excludeInherited}});
         if (events && events.length && events.forEach) {
     ?>
         <h3 class="subsection-title">Events</h3>


### PR DESCRIPTION
# Pull Request Template

## Description

Add an option to excludes inherited symbols.

When you have a lot of classes with inheritance, the last child will inherit from all its ancestor. Potentially having a lot of methods polluting the documentation.

Sometimes, it could be better to display all available methods, but in my case it created too much noise. That's why I left it under an option. If users don't set this option to `true`, then the current behavior is used.

## Type of change

Please mark options that is/are relevant.
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
- [ ] Other (if so, then explain below briefly)
