### PR TITLE
Navbar fixes

### DIFF
--- a/publish.js
+++ b/publish.js
@@ -732,7 +732,7 @@ function buildNav(members) {
         [SECTION_TYPE.Modules]: buildMemberNav({
             itemHeading: 'Modules',
             items: members.modules,
-            itemsSeen: {},
+            itemsSeen: seen,
             linktoFn: linkto,
             sectionName: SECTION_TYPE.Modules
         }),

--- a/publish.js
+++ b/publish.js
@@ -579,7 +579,8 @@ function buildMemberNav({
                     [] :
                     find({
                         kind: 'function',
-                        memberof: item.longname
+                        memberof: item.longname,
+                        inherited: {'!is': Boolean(themeOpts.exclude_inherited)}
                     });
 
             if (!hasOwnProp.call(item, 'longname')) {

--- a/publish.js
+++ b/publish.js
@@ -637,7 +637,7 @@ function buildMemberNav({
                     itemsNav += "<ul class='methods accordion-content'>";
 
                     methods.forEach(function(method) {
-                        var name = method.longname.split('#');
+                        var name = method.longname.split(method.scope === 'static' ? '.' : '#');
                         var first = name[0];
                         var last = name[1];
 

--- a/static/scripts/search.js
+++ b/static/scripts/search.js
@@ -39,10 +39,8 @@ function search(list, options, keys, searchKey) {
 
     var result = fuse.search(searchKey);
 
-    console.log(result, result.length);
     if (result.length > 20) { result = result.slice(0, 20); }
 
-    console.log(result);
     var searchUL = document.getElementById('search-item-ul');
 
     searchUL.innerHTML = '';
@@ -79,5 +77,3 @@ function setupSearch(list, options) {
         window.addEventListener('click', checkClick);
     });
 }
-
-

--- a/static/scripts/search.js
+++ b/static/scripts/search.js
@@ -43,14 +43,12 @@ function search(list, options, keys, searchKey) {
 
     var searchUL = document.getElementById('search-item-ul');
 
-    searchUL.innerHTML = '';
-
     if (result.length === 0) {
-        searchUL.innerHTML += '<li class="p-h-n"> No Result Found </li>';
+        searchUL.innerHTML = '<li class="p-h-n"> No Result Found </li>';
     } else {
-        result.forEach(function(obj) {
-            searchUL.innerHTML += '<li>' + obj.item.link + '</li>';
-        });
+        searchUL.innerHTML = result.reduce(function(html, obj) {
+            return html + '<li>' + obj.item.link + '</li>';
+        }, '');
     }
 }
 


### PR DESCRIPTION
# Pull Request Template

## Description

I made a few fixes to the navbar following my recent PR about inherited methods. Here's the list:
 - Modules were not using the `seen` object to track duplicates
 - Remove inherited methods when the `exclude_inherited` option is used
 - Static methods were displaying a wrong name ("Class.staticMethod > undefined" fixed to "Class > staticMethod")

I also made two changes that don't impact behavior in any way:
 - Remove `console.log`
 - Write in search DOM only once


## Type of change

Please mark options that is/are relevant.
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Other (if so, then explain below briefly)
