### PR TITLE
Fix the example jsdoc config in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,11 +90,12 @@ For more information look at [https://github.com/ankitskvmdam/clean-jsdoc-theme-
         "template": "./node_modules/clean-jsdoc-theme",
         "theme_opts": {
             "default_theme": "dark"
-        },
-        "markdown": {
-            "hardwrap": false,
-            "idInHeadings": true // This is important for clean-jsdoc-theme, otherwise some features might not work.
         }
+    },
+    
+    "markdown": {
+      "hardwrap": false,
+      "idInHeadings": true // This is important for clean-jsdoc-theme, otherwise some features might not work.
     }
 }
 ```


### PR DESCRIPTION
## Description

Fixes #103 :  in the jsdoc config example of the README, the ``markdown`` object is a child of the ``opts`` object.

The use of this jsdoc configuration causes links inside the "On this page" section referring to the README content to not work properly.

As seen inside the file ``jsdoc-config.json``, the ``markdown`` object should be a child of the root object.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Other (if so, then explain below briefly)
