### PR TITLE
fix: fix extra \t at start of all lines, excludes first line

### DIFF
--- a/static/scripts/core.js
+++ b/static/scripts/core.js
@@ -272,7 +272,11 @@ function copyFunction(id) {
   }
 
   // copy
-  copy(element.innerText.trim());
+  copy(
+    element.innerText
+      .trim()
+      .replace(/(^\t)/gm, '')
+  );
 
   // show tooltip
   showTooltip('tooltip-' + id);

--- a/static/scripts/third-party/hljs-line-num-original.js
+++ b/static/scripts/third-party/hljs-line-num-original.js
@@ -123,7 +123,11 @@
                 // other browsers can directly use the selection string
                 selectionText = selection.toString();
             }
-            e.clipboardData.setData('text/plain', selectionText);
+            e.clipboardData.setData(
+              'text/plain',
+              selectionText
+                .replace(/(^\t)/gm, '')
+            );
             e.preventDefault();
         }
     });


### PR DESCRIPTION
## Description

Fix #144

Perhaps this is not the best solution. But one of the options

You can try this on this [example](https://clean-jsdoc-theme.deta.dev/v4/index.html)

Regex matches only first `\t` - [regex101](https://regex101.com/r/nFnKuV/1)

## Type of change

Please mark options that is/are relevant.
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Other (if so, then explain below briefly)
