### PR TITLE
✨ add module header option

### DIFF
--- a/publish.js
+++ b/publish.js
@@ -430,6 +430,12 @@ function buildFooter() {
     return footer;
 }
 
+function moduleHeader() {
+    var displayModuleHeader = themeOpts.displayModuleHeader || false;
+
+    return displayModuleHeader;
+}
+
 function getFavicon() {
     var favicon = themeOpts.favicon || undefined;
 
@@ -960,6 +966,7 @@ exports.publish = function (taffyData, opts, tutorials) {
     view.htmlsafe = htmlsafe;
     view.outputSourceFiles = outputSourceFiles;
     view.footer = buildFooter();
+    view.displayModuleHeader = moduleHeader();
     view.favicon = getFavicon();
     view.dynamicStyle = createDynamicStyleSheet();
     view.dynamicStyleSrc = returnPathOfStyleSrc();

--- a/tmpl/container.tmpl
+++ b/tmpl/container.tmpl
@@ -39,6 +39,11 @@
         <?js } ?>
     <?js } else if (doc.kind === 'module' && doc.modules) { ?>
         <?js doc.modules.forEach(function(module) { ?>
+            <?js if (module.name && self.displayModuleHeader) { ?>
+                <h1 id="<?js= module.name ?>-title" class="has-anchor">
+                    <?js= module.name ?>
+                </h1>
+            <?js } ?>
             <?js if (module.classdesc) { ?>
                 <div class="class-description"><?js= module.classdesc ?></div>
             <?js } ?>


### PR DESCRIPTION
# Pull Request Template

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

No dependency changes, just adds a new option to the jsDocs config for choosing if you want the module name to appear on its page.

Fixes # (issue)

#172 

## Type of change

Please mark options that is/are relevant.
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] This change requires a documentation update
- [ ] Other (if so, then explain below briefly)

## How it works

### Display Module Header

```JSON
"theme_opts": {
  "displayModuleHeader":  true // default=false
}
```

### Default

![image](https://user-images.githubusercontent.com/26221344/205810069-05142945-2540-4f6e-b40e-eb4ef7109aad.png)

### Enabled
![image](https://user-images.githubusercontent.com/26221344/205809032-04eb9a10-9863-4692-bd50-ad46d12141f6.png)
