### PR TITLE
use jsdoc's built in commonPrefix defined in `jsdoc/path`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
             "license": "MIT",
             "dependencies": {
                 "@jsdoc/salty": "^0.2.2",
-                "common-path-prefix": "^3.0.0",
                 "fs-extra": "^10.1.0",
                 "html-minifier": "^4.0.0",
                 "klaw-sync": "^6.0.0",
@@ -514,11 +513,6 @@
             "version": "2.20.3",
             "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
             "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
-        },
-        "node_modules/common-path-prefix": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/common-path-prefix/-/common-path-prefix-3.0.0.tgz",
-            "integrity": "sha512-QE33hToZseCH3jS0qN96O/bSh3kaw/h+Tq7ngyY9eWDUnTlTNUyqfqvCXioLe5Na5jFsL78ra/wuBU4iuEgd4w=="
         },
         "node_modules/concat-map": {
             "version": "0.0.1",
@@ -3869,11 +3863,6 @@
             "version": "2.20.3",
             "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
             "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
-        },
-        "common-path-prefix": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/common-path-prefix/-/common-path-prefix-3.0.0.tgz",
-            "integrity": "sha512-QE33hToZseCH3jS0qN96O/bSh3kaw/h+Tq7ngyY9eWDUnTlTNUyqfqvCXioLe5Na5jFsL78ra/wuBU4iuEgd4w=="
         },
         "concat-map": {
             "version": "0.0.1",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
     },
     "dependencies": {
         "@jsdoc/salty": "^0.2.2",
-        "common-path-prefix": "^3.0.0",
         "fs-extra": "^10.1.0",
         "html-minifier": "^4.0.0",
         "klaw-sync": "^6.0.0",

--- a/publish.js
+++ b/publish.js
@@ -1,5 +1,4 @@
 const _ = require('lodash');
-const commonPathPrefix = require('common-path-prefix');
 const env = require('jsdoc/env');
 const fs = require('fs-extra');
 const helper = require('jsdoc/util/templateHelper');
@@ -779,7 +778,7 @@ exports.publish = function (taffyData, opts, tutorials) {
     if (sourceFilePaths.length) {
         sourceFiles = shortenPaths(
             sourceFiles,
-            commonPathPrefix(sourceFilePaths)
+            path.commonPrefix(sourceFilePaths)
         );
     }
 


### PR DESCRIPTION
# Pull Request Template

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Currently we are using `common-path-prefix` that fails to return a common path when there is only one file. Instead of using `common-path-prefix` now we can using `path.commonPrefix` (path is from `jsdoc/path`). This will return the root directory if there is only one file, instead of returning the absolute path.

Fixes #192  

## Type of change

Please mark options that is/are relevant.
- [ x ] Bug fix (non-breaking change which fixes an issue)
