### PR TITLE
Fix how exclude_inherited option filters out items

### DIFF
--- a/tmpl/container.tmpl
+++ b/tmpl/container.tmpl
@@ -91,7 +91,8 @@
     <?js } ?>
 
     <?js
-        var classes = self.find({kind: 'class', memberof: doc.longname, ...(self.excludeInherited && {inherited: {'!is': self.excludeInherited}}) } );
+        var shouldExcludeInherited = { ...(self.excludeInherited ? { inherited: {isUndefined: true} } : {}) };
+        var classes = self.find({kind: 'class', memberof: doc.longname, ...shouldExcludeInherited } );
         if (!isGlobalPage && classes && classes.length) {
     ?>
         <h2 id="classes" class="subsection-title has-anchor">Classes</h2>
@@ -103,7 +104,7 @@
     <?js } ?>
 
     <?js
-        var interfaces = self.find({kind: 'interface', memberof: doc.longname, ...(self.excludeInherited && {inherited: {'!is': self.excludeInherited}})});
+        var interfaces = self.find({kind: 'interface', memberof: doc.longname, ...shouldExcludeInherited});
         if (!isGlobalPage && interfaces && interfaces.length) {
     ?>
         <h2 id="interfaces" class="subsection-title has-anchor">Interfaces</h2>
@@ -115,7 +116,7 @@
     <?js } ?>
 
     <?js
-        var mixins = self.find({kind: 'mixin', memberof: doc.longname, ...(self.excludeInherited && {inherited: {'!is': self.excludeInherited}})});
+        var mixins = self.find({kind: 'mixin', memberof: doc.longname, ...shouldExcludeInherited});
         if (!isGlobalPage && mixins && mixins.length) {
     ?>
         <h2 id="mixins" class="subsection-title has-anchor">Mixins</h2>
@@ -127,7 +128,7 @@
     <?js } ?>
 
     <?js
-        var namespaces = self.find({kind: 'namespace', memberof: doc.longname, ...(self.excludeInherited && {inherited: {'!is': self.excludeInherited}})});
+        var namespaces = self.find({kind: 'namespace', memberof: doc.longname, ...shouldExcludeInherited});
         if (!isGlobalPage && namespaces && namespaces.length) {
     ?>
         <h2 id="namespaces" class="subsection-title has-anchor">Namespaces</h2>
@@ -139,7 +140,7 @@
     <?js } ?>
 
     <?js
-        var members = self.find({kind: 'member', memberof: isGlobalPage ? {isUndefined: true} : doc.longname, ...(self.excludeInherited && {inherited: {'!is': self.excludeInherited}})});
+        var members = self.find({kind: 'member', memberof: isGlobalPage ? {isUndefined: true} : doc.longname, ...shouldExcludeInherited});
 
         // symbols that are assigned to module.exports are not globals, even though they're not a memberof anything
         if (isGlobalPage && members && members.length && members.forEach) {
@@ -157,7 +158,7 @@
     <?js } ?>
 
     <?js
-        var methods = self.find({kind: 'function', memberof: isGlobalPage ? {isUndefined: true} : doc.longname, ...(self.excludeInherited && {inherited: {'!is': self.excludeInherited}})});
+        var methods = self.find({kind: 'function', memberof: isGlobalPage ? {isUndefined: true} : doc.longname, ...shouldExcludeInherited});
         if (methods && methods.length && methods.forEach) {
     ?>
         <h2 id="methods" class="subsection-title has-anchor">Methods</h2>
@@ -168,7 +169,7 @@
     <?js } ?>
 
     <?js
-        var typedefs = self.find({kind: 'typedef', memberof: isGlobalPage ? {isUndefined: true} : doc.longname, ...(self.excludeInherited && {inherited: {'!is': self.excludeInherited}})});
+        var typedefs = self.find({kind: 'typedef', memberof: isGlobalPage ? {isUndefined: true} : doc.longname, ...shouldExcludeInherited});
         if (typedefs && typedefs.length && typedefs.forEach) {
     ?>
         <h2 id="type-definitions" class="subsection-title has-anchor">Type Definitions</h2>
@@ -188,7 +189,7 @@
     <?js } ?>
 
     <?js
-        var events = self.find({kind: 'event', memberof: isGlobalPage ? {isUndefined: true} : doc.longname, ...(self.excludeInherited && {inherited: {'!is': self.excludeInherited}})});
+        var events = self.find({kind: 'event', memberof: isGlobalPage ? {isUndefined: true} : doc.longname, ...shouldExcludeInherited});
         if (events && events.length && events.forEach) {
     ?>
         <h2 id="events" class="subsection-title has-anchor">Events</h2>


### PR DESCRIPTION
# Pull Request Template

## Description

Third time the charm. I guess it was a change in Taffy's API, otherwise I don't understand how the bug appeared.

Should be fixed and hopefully more resilient.

Fixes #250

## Type of change

Please mark options that is/are relevant.
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Other (if so, then explain below briefly)
