### PR TITLE
fix: v4.2.15 breaks building docs

### DIFF
--- a/tmpl/include-target-script-and-styles.tmpl
+++ b/tmpl/include-target-script-and-styles.tmpl
@@ -5,24 +5,28 @@ const scripts = []
 const styles = []
 
 
-for (const script of this.includeScript) {
-    if(typeof script === 'object') {
-        for (const target of script.targets) {
-            if(filename === target) {
-                scripts.push(script.filepath)
+if(Array.isArray(this.includeScript)) {
+    for (const script of this.includeScript) {
+        if(typeof script === 'object') {
+            for (const target of script.targets) {
+                if(filename === target) {
+                    scripts.push(script.filepath)
+                }
             }
-        }
-    }    
+        }    
+    }
 }
 
-for (const style of this.includeCss) {
-    if(typeof style === 'object') {
-        for (const target of style.targets) {
-            if(filename === target) {
-                styles.push(style.filepath)
+if(Array.isArray(this.includeCss)) {
+    for (const style of this.includeCss) {
+        if(typeof style === 'object') {
+            for (const target of style.targets) {
+                if(filename === target) {
+                    styles.push(style.filepath)
+                }
             }
-        }
-    }    
+        }    
+    }
 }
 
 


### PR DESCRIPTION
In v4.2.15 we have added a feature to include scripts and styles only in target files. In order to do so we are looping through `this.includeScript` and `this.includeCss`. However we are not checking whether these are defined.

So, for users who don't want to include any script/style above mentioned variables are `undefined` for them, hence causing the build to fail because `undefined` is not iterable.

This PR fixes this issue, as now we are checking whether these variables are defined.

fixes: #259
