### PR TITLE
Skill authoring: progressive-disclosure split + name/folder fix

### DIFF
--- a/SKILLS/clean-jsdoc-theme/SKILL.md
+++ b/SKILLS/clean-jsdoc-theme/SKILL.md
@@ -16,12 +16,24 @@ description: >-
 This skill makes you an expert at **using and extending `clean-jsdoc-theme` v5**.
 Everything here is verified against the source. When a user is documenting a
 JS/TS project with this theme, configuring it, authoring prose, or hacking on the
-packages, follow this document over your prior assumptions about "a JSDoc theme."
+packages, follow this over your prior assumptions about "a JSDoc theme."
 
-> **Skill revision:** `2026-06-13`. This skill is versioned with the theme — see
-> [§13 Staying current](#13-staying-current) for how (and how often) to check for
-> a newer copy and a newer theme release.
+This file is the **operating guide**: the mental model, setup, and behaviour. The
+detailed reference lives in sibling files under `reference/` — **read the one that
+matches the task** (don't load them all):
 
+| Read this when… | File |
+| --- | --- |
+| Writing/validating `jsdoc.json` / `typedoc.json` options | [`reference/configuration.md`](reference/configuration.md) |
+| Authoring prose: callouts, steps, tabs, embeds, custom tags | [`reference/authoring.md`](reference/authoring.md) |
+| The docs directory, frontmatter, sidebar order, cross-links | [`reference/content-and-sidebar.md`](reference/content-and-sidebar.md) |
+| Contributing to the packages (utils/setu/rang/dwar) | [`reference/architecture.md`](reference/architecture.md) |
+| A build misbehaves / something doesn't render | [`reference/troubleshooting.md`](reference/troubleshooting.md) |
+
+> **Skill revision:** `2026-06-13`. Versioned with the theme — see
+> [§6 Staying current](#6-staying-current) for how (and how often) to check for a
+> newer skill or theme release.
+>
 > Project: <https://github.com/ankitskvmdam/clean-jsdoc-theme> ·
 > npm: `clean-jsdoc-theme` (JSDoc) and `@clean-jsdoc-theme/typedoc` (TypeDoc).
 
@@ -42,29 +54,24 @@ JSDoc doclets  ─┐
 TypeDoc reflns ─┘        (no I/O)                                 (pure, uses rang components)
 ```
 
-What `render()` emits per build:
+`render()` emits, per build: `‹slug›/index.html` per page (SSR + lazy-hydrated
+Preact islands, only the islands a page uses); `‹slug›/index.md` per content page
+(a **companion Markdown** authored for LLMs — the theme's defining feature);
+`_assets/styles.‹buildId›.css`; `_assets/search-index.‹buildId›.json` (the `Ctrl K`
+fuzzy index); `_islands/‹name›.js`; and optionally a **Pagefind** full-text index.
 
-- `‹slug›/index.html` per page — server-rendered, with lazy-hydrated **Preact
-  islands** (only the islands a page uses are shipped to it).
-- `‹slug›/index.md` per content page — a **companion Markdown** of the page,
-  authored to be ideal for LLMs (this is the theme's defining feature).
-- `_assets/styles.‹buildId›.css` — one stylesheet (Tailwind v4, prebuilt).
-- `_assets/search-index.‹buildId›.json` — fuzzy search index for the `Ctrl K`
-  palette (titles, descriptions, full text, plus a deep-link entry per member).
-- `_islands/‹name›.js` — one content-hashed chunk per island + a shared chunk.
-- Optionally a **Pagefind** full-text index (separate post-write step).
-
-Key guarantees worth knowing: **setu does no disk I/O** (the bridge reads files),
-**dwar.render() is pure** (no `fs`, no `process.cwd`), and **one page that fails
-to compile is skipped and reported, never aborts the build**.
+Guarantees worth knowing: **setu does no disk I/O** (the bridge reads files),
+**dwar.render() is pure**, and **one page that fails to compile is skipped and
+reported, never aborts the build**.
 
 ---
 
 ## 2. Setup
 
-The theme has two entry points. Pick the one matching the user's toolchain. The
-**option names and values are identical** between them — only *where you put
-them* differs: JSDoc uses `opts`, TypeDoc uses a `cleanJsdocTheme` block.
+Two entry points. Pick the one matching the toolchain. The **option names and
+values are identical** between them — only *where you put them* differs: JSDoc
+uses `opts`, TypeDoc uses a `cleanJsdocTheme` block. (Full option list:
+[`reference/configuration.md`](reference/configuration.md).)
 
 ### JSDoc
 
@@ -72,12 +79,11 @@ them* differs: JSDoc uses `opts`, TypeDoc uses a `cleanJsdocTheme` block.
 npm install --save-dev jsdoc clean-jsdoc-theme
 ```
 
-`jsdoc.json`:
-
 ```json5
+// jsdoc.json
 {
   source: { include: ["./src", "./README.md"] },
-  plugins: ["plugins/markdown"],          // REQUIRED — see gotcha below
+  plugins: ["plugins/markdown"],          // REQUIRED — see note below
   opts: {
     template: "node_modules/clean-jsdoc-theme/dist",
     destination: "dist",
@@ -88,13 +94,12 @@ npm install --save-dev jsdoc clean-jsdoc-theme
 }
 ```
 
-Build: `npx jsdoc -c jsdoc.json` → output in `dist/`. Serve with `npx serve dist`
-(Pagefind needs HTTP, so opening `index.html` from disk won't load full-text
-search).
+Build: `npx jsdoc -c jsdoc.json` → `dist/`. Serve with `npx serve dist` (Pagefind
+needs HTTP, so opening `index.html` from disk won't load full-text search).
 
-> **Critical gotcha:** the `plugins/markdown` plugin is **required**. JSDoc
-> renders comment Markdown → HTML *before* the theme sees it, and the theme
-> consumes that HTML. Without it, descriptions arrive as raw, unformatted text.
+> **Required:** the `plugins/markdown` plugin. JSDoc renders comment Markdown →
+> HTML *before* the theme sees it, and the theme consumes that HTML. Without it,
+> descriptions arrive as raw, unformatted text.
 
 ### TypeDoc
 
@@ -102,9 +107,8 @@ search).
 npm install --save-dev typedoc @clean-jsdoc-theme/typedoc
 ```
 
-`typedoc.json`:
-
 ```json5
+// typedoc.json
 {
   entryPoints: ["src/index.ts"],
   tsconfig: "tsconfig.json",
@@ -116,10 +120,8 @@ npm install --save-dev typedoc @clean-jsdoc-theme/typedoc
 ```
 
 It registers a custom **output** (not a CSS theme extending `DefaultTheme`). Build
-with `npx typedoc`.
-
-Runnable references in the repo: `examples/basic` (JSDoc), `examples/typedoc-basic`
-(TypeDoc), and `docs-site/` (a prose-first dogfood site).
+with `npx typedoc`. Runnable references in the repo: `examples/basic` (JSDoc),
+`examples/typedoc-basic` (TypeDoc), `docs-site/` (a prose-first dogfood site).
 
 ---
 
@@ -127,12 +129,12 @@ Runnable references in the repo: `examples/basic` (JSDoc), `examples/typedoc-bas
 
 | Source | Result |
 | --- | --- |
-| Each container symbol — `class`, `interface`, `mixin`, `module`, `namespace` | One page, members bucketed into sections. class/interface also fold in inherited members via `@augments`/`@extends`. |
-| `typedef` | Its own page (first-class — `@type`, `@property`, and function-signature `@param`/`@returns` all render). |
-| Every **global-scope** symbol without its own page | Collected onto one aggregated **"Globals"** page. |
-| `events`, `enums`, `constants` | Rendered as member **sections within their parent**, not standalone pages. |
-| `@module`/README/tutorial/doc Markdown | Prose pages (see §6). |
-| Each documented **source file** | A hidden Monaco-powered source viewer page + a "Source Files" index; each member gets a `Source: file:line` link (on by default). |
+| Container symbol — `class`, `interface`, `mixin`, `module`, `namespace` | One page; members bucketed into sections. class/interface fold in inherited members via `@augments`/`@extends`. |
+| `typedef` | Its own page (first-class — `@type`, `@property`, function-signature `@param`/`@returns`). |
+| Every **global-scope** symbol without its own page | One aggregated **"Globals"** page. |
+| `events`, `enums`, `constants` | Member **sections within their parent**, not standalone pages. |
+| README / tutorials / `opts.docs` Markdown | Prose pages (see [`reference/content-and-sidebar.md`](reference/content-and-sidebar.md)). |
+| Each documented **source file** | A Monaco source-viewer page + a "Source Files" index; each member gets a `Source: file:line` link (default on). |
 
 A **class page** leads with the class description (`classdesc`), then a
 **Constructor** section (on every class unless `@hideconstructor`): the call
@@ -144,391 +146,7 @@ and the parameter table.
 
 ---
 
-## 4. Configuration reference
-
-All options below are identical for both tools — only the namespace differs
-(`opts` for JSDoc, `cleanJsdocTheme` for TypeDoc).
-
-> Unknown / misspelled keys only **warn** (with a "did you mean?" hint) and the
-> build continues. Set `strict: true` to escalate warnings to hard errors.
-
-### Site & identity
-
-| Option | Type | Notes |
-| --- | --- | --- |
-| `siteName` | string \| logo set | Header title. Logo set: `{ light, dark, default, alt }` (URLs or local paths; dark/light swap via CSS). Defaults to the package `name`. Local logos are copied to content-hashed `_assets/`. |
-| `basePath` | string | Root path prefixed onto every internal link/asset, for sub-path hosting (`/my-lib`). Default `""`. |
-
-### Content sources
-
-| Option | Type | Notes |
-| --- | --- | --- |
-| `readme` | path | Markdown rendered as the **home page** (slug `""`). A root `docs/index.md` overrides it. |
-| `docs` | dir path | A directory of hand-written `.md`/`.markdown`/`.html` guides → prose pages. Folder layout drives URL + sidebar group (see §6). |
-| `docGroups` | string[] | Display order of top-level **doc** groups in the sidebar. |
-| `defaultDocGroup` | string | Group a doc lands in when it declares none. |
-| `tutorials` | dir path | JSDoc `--tutorials` tree → guide pages under a "Tutorials" group (sub-tutorials nest). Equivalent to JSDoc's `-u`. |
-
-### Sidebar & navigation (see §7 for the full model)
-
-| Option | Type | Notes |
-| --- | --- | --- |
-| `sectionOrder` | string[] | Order of **all** top-level sections (kind labels AND doc/category groups). Listed first, rest appended. For kind labels it's also a filter — an **omitted kind label is dropped**; category/doc groups are never dropped by omission. |
-| `clubSidebarItems` | boolean | Collapse related entries under a shared collapsible parent, grouped by the path segment before the first `/`. Default `false`. Applies **only** to kind-label fallback buckets, never to `@category`-built groups. |
-| `menu` | entry[] | Custom links pinned above the sidebar. Each: `{ title, link (or href), id?, icon? }`. `icon` is `lucide:<name>` or `simpleicons:<name>` (CDN-loaded). When set, `menu` owns the auto Home/Source links (suppressed unless you list `{ id: "home" }` / `{ id: "source" }`). |
-
-### Appearance & assets
-
-| Option | Type | Notes |
-| --- | --- | --- |
-| `fonts` | `{ heading?, body?, mono? }` | `heading`/`body` are Google Font family names (loaded for you, existence-checked at build); `mono` is a CSS font stack. |
-| `colors` | color map | Light-mode palette; merges **per key** over the built-in palette. Keys: `bg`, `bgMuted`, `fg`, `fgMuted`, `accent`, `accentFg`, `border`. Any valid CSS color (ships OKLCH). |
-| `darkColors` | color map | Same keys, emitted under `[data-theme="dark"]`. Omit it and dark mode falls back to a sensible bg/fg swap. |
-| `customCss` / `customJs` | string | Inline CSS/JS injected on every page. CSS loads **after** the theme stylesheet (overrides win); JS runs **last**. |
-| `customCssFile` / `customJsFile` | path | Same, read from disk; copied to content-hashed `_assets/`. |
-| `hashCustomAssets` | boolean | Content-hash custom-asset filenames for cache-busting. Default `true`. |
-
-### LLM & copy-page
-
-| Option | Type | Notes |
-| --- | --- | --- |
-| `copyPage` | boolean \| `{ enabled, actions }` | The per-page copy / open-in-LLM button (content pages only). `actions` ⊂ `copy`, `view`, `claude`, `chatgpt`, `perplexity`. On by default with all actions. |
-| `aiPrompt` | string | Instruction prepended when a page is handed to an LLM via the open-in actions. |
-
-### Build
-
-| Option | Type | Notes |
-| --- | --- | --- |
-| `strict` | boolean | Escalate option diagnostics (bad font, unknown key) from warnings to hard errors. Default `false`. |
-| `progress` | boolean | Toggle per-stage build spinners. Default `true`. |
-
-### JSDoc-only (under `templates.default`, NOT `opts`)
-
-```json5
-templates: { default: { outputSourceFiles: false, sourceLinkToComment: true } }
-```
-
-- `outputSourceFiles` (default `true`) — generate the source-file viewer pages
-  and `Source: file:line` links.
-- `sourceLinkToComment` (default `false`) — land a `Source:` link on the doc
-  **comment** instead of the **declaration**.
-
-### Asset handling (automatic — no config)
-
-Any image referenced from docs/README with a relative or root-relative path is
-copied into `_assets/` under a **content-hashed** name and the ref is rewritten.
-`.svg` files are **inlined** into the page so their own `[data-theme="dark"]`
-styles can follow the in-page theme toggle (an `<img>` SVG can't). External
-(`https://`) and `data:` URLs are left untouched.
-
----
-
-## 5. Authoring rich content
-
-All of these work in **prose** (README, tutorials, the `docs` directory). Several
-also work directly inside **JSDoc/TypeDoc comment descriptions**. There is no
-dedicated block tag for steps/tabs/callouts — you write the same markup in either
-place and it flows through one converter.
-
-### Callouts — GitHub-style alert blockquotes
-
-```markdown
-> [!NOTE]
-> Useful information, even when skimming.
-```
-
-Four variants; markers are case-insensitive and several keywords fold onto each:
-
-| Marker | Variant |
-| --- | --- |
-| `[!INFO]` `[!NOTE]` `[!IMPORTANT]` | info (blue) |
-| `[!TIP]` `[!SUCCESS]` | tip (green) |
-| `[!WARNING]` `[!CAUTION]` | warning (amber) |
-| `[!ERROR]` `[!DANGER]` | error (red) |
-
-The marker must be the first thing in the blockquote; it's stripped from the
-body. Bodies are full Markdown and callouts promote at any depth (incl. inside
-list items). A `@deprecated` doc-comment tag **auto-emits** an error callout (with
-a kind-aware default sentence when no reason is given).
-
-### Steps — numbered stepper (SSR, no JS)
-
-```markdown
-<steps>
-
-<step label="Install">
-
-Add the package as a dev dependency.
-
-</step>
-
-<step label="Build">
-
-Run the build and open the output.
-
-</step>
-
-</steps>
-```
-
-`label` is optional. **Leave a blank line around each step's inner content** —
-each body is re-parsed as Markdown, so blank lines are what let fenced
-code/lists/nested containers parse. You can nest tabs, callouts, code, even
-another `<steps>` inside a step.
-
-### Tabs — tabbed view (SSR + a light enhancement island)
-
-```markdown
-<tabs group="pm">
-
-<tab label="npm">
-
-```sh
-npm install clean-jsdoc-theme
-```
-
-</tab>
-
-<tab label="pnpm">
-
-```sh
-pnpm add clean-jsdoc-theme
-```
-
-</tab>
-
-</tabs>
-```
-
-- `<tab label>` — button text (falls back to `Tab N`).
-- `<tab value>` — cross-block sync key; defaults to the normalized label, so
-  **identical labels sync for free**.
-- `<tabs group>` — opts the block into cross-block syncing: give multiple blocks
-  the same `group` and switching one switches all (persisted across visits).
-
-Same blank-line rule as steps.
-
-### Embeds — sandboxed iframes / live demos
-
-Two authoring forms, **one config grammar** (`<url> key=value flag`):
-
-Prose fence:
-
-````markdown
-```iframe
-https://example.com/embed/demo title="Live demo" height=420
-```
-````
-
-Source-comment block tag (requires `tags.allowUnknownTags: true`):
-
-```js
-/** @iframe https://example.com/embed/demo title="Demo" aspectRatio=16/9 */
-```
-
-- **First token = URL.** Only `https://` or protocol-relative `//` URLs are
-  accepted; anything else is dropped with a warning.
-- Options: `title`, `width` (CSS, default `100%`), `height` (px, default `400`),
-  `aspectRatio` (e.g. `16/9`, preferred over height), `allow`, `sandbox`,
-  `clickToLoad` (poster instead of live iframe), `themed`.
-- `themed` is **on by default**: a `{theme}` token in the URL is swapped for
-  `light`/`dark`; else an author `theme-id` param wins; else `?theme-id=<theme>`
-  is appended. Opt out with `themed=false`. Both live and click-to-load work with
-  no JS (`<noscript>` fallback).
-
-### Custom doc-comment tags
-
-All three are **unknown tags** → require `tags.allowUnknownTags: true` in
-`jsdoc.json` (without it JSDoc strips them before the theme runs):
-
-- **`@category <path> [order=N]`** — put a symbol's page in an explicit sidebar
-  group. The group path is the **leading whitespace-separated tokens joined with
-  a single space** (so `@category Getting Started` is one flat group named
-  "Getting Started"); parsing switches to `key=value` options at the first token
-  containing `=`. A literal **`/` nests** (`Core/Parsing` → Core ▸ Parsing).
-  First `@category` wins.
-- **`@order N`** — within-group sort key for any symbol, including a plain
-  `@module`/`@class` in its kind section. When both are present,
-  `@category … order=` wins over a standalone `@order`.
-- **`@iframe`** — see Embeds above.
-
----
-
-## 6. The docs directory & frontmatter
-
-Point `opts.docs` at a directory. Each `.md`/`.markdown`/`.html`/`.htm` file
-becomes one page; `node_modules`, `.git`, and dotfiles are skipped. The filesystem
-drives the URL and sidebar group:
-
-| Field | Derivation (first match wins) |
-| --- | --- |
-| `slug` | frontmatter `slug` → slugified relative path with **no prefix**; `index` → `""` |
-| `title` | frontmatter `title` → humanized basename |
-| `group` | frontmatter `group` → humanized **directory** path → `defaultDocGroup` |
-| `order` | frontmatter `order` |
-| `hidden` | frontmatter `hidden` (default `false`; hidden = rendered but kept out of the sidebar) |
-
-So `guides/Advanced Setup.md` → `/guides/advanced-setup` in group **Guides**;
-`guides/setup/install.md` → nested group **Guides/Setup**. A root `index.md` is
-the home page and **overrides `readme`**.
-
-Frontmatter is a leading `---` block of **flat `key: value` scalars only** — no
-nested YAML, lists, or multi-line values. A malformed/unterminated block is
-treated as no frontmatter.
-
-```markdown
----
-title: Advanced Setup
-group: Guides
-order: 2
-slug: guides/advanced
-hidden: false
----
-
-# Advanced Setup
-```
-
----
-
-## 7. The sidebar model (one engine, several levers)
-
-Every navigable entry — API symbol, guide page, tutorial — carries a **`group`
-path** (the bold top-level title, optionally a `/`-nested branch) and an optional
-**`order`** (within-group sort key). That single abstraction is why a guide and a
-class can share a sidebar group.
-
-Where they come from:
-
-| Source | `group` | `order` |
-| --- | --- | --- |
-| API symbol | `@category`, else kind label (Classes, …) | `@category … order=`, else `@order` |
-| Guide page | frontmatter `group`, else directory, else `defaultDocGroup` | frontmatter `order` |
-| Tutorial | the tutorial hierarchy (`Tutorials/<parent>/…`) | resolved tree order |
-
-The levers:
-
-1. **`@category` / `@order`** (source tags, §5) — group and order API symbols.
-2. **`/`-paths nest** — first segment = bold top-level title, deeper segments =
-   collapsible branches. Works from `@category`, frontmatter `group`, or directory.
-3. **Leaf-vs-branch order:** within a level, sort by effective order ascending (a
-   branch's effective order = the **min `order` of any page inside it**, so
-   `order=1` on one nested page floats its whole subgroup up); ties → leaves
-   before branches; then first-seen. No-order entries sort last, then alphabetical.
-4. **`clubSidebarItems`** — collapse kind-label buckets by the prefix before the
-   first `/` in their label (`queue`, `queue/Queue` → a `queue` parent; the bare
-   `queue` becomes an `index` child). Mutually exclusive with `@category` nesting.
-5. **`sectionOrder`** — order the top-level sections (kind labels + group names in
-   one list). Omitted kind labels are dropped; category/doc groups are appended.
-6. **`docGroups` / `defaultDocGroup`** — order doc-group sections (appended after
-   API sections unless also named in `sectionOrder`); fallback group for ungrouped docs.
-7. **`menu`** — a top region above the sections, each with an icon.
-
-Mixing guides interleaved with API kinds (Classes between two prose groups) needs
-`sectionOrder`; `docGroups` alone always appends doc groups after API sections.
-
----
-
-## 8. Cross-references & source links
-
-- **`{@link}` / `{@linkcode}` / `{@linkplain}`** inline tags and **`@see`** block
-  tags resolve to real cross-page anchors. setu builds a link registry from the
-  pages it actually generates (two-pass, so forward references resolve), rewriting
-  namepaths → page-slug + `#member` anchor.
-- External URLs (`http(s)://`, `mailto:`) link directly (and `https://` opens in a
-  new tab). Unresolved namepaths fall back to inline code (the look JSDoc text had).
-- A **bare short name** (`{@link BaseEntity}`) resolves only when unambiguous
-  across the whole registry — ambiguous names refuse to guess.
-- Every documented member gets a `Source: file:line` link (default on) landing on
-  the declaration line; the source-viewer page opens Monaco to that exact line.
-
----
-
-## 9. LLM-friendliness (the theme's signature feature)
-
-- A **companion `.md`** is emitted next to every content page (`‹slug›/index.md`)
-  — the page's body as clean Markdown, authored for machine reading.
-- A **copy-page split button** on content pages: copy that `.md`, view it, or open
-  the page in **Claude / ChatGPT / Perplexity** (it hands over the `.md` + an
-  optional `aiPrompt`, never the rendered HTML). Configurable via `copyPage`.
-- The `Ctrl K` palette fetches the search index lazily and ranks across title,
-  description, and full page text, with a deep-link entry per member heading.
-
-When advising a user who cares about AI consumption: every page is already
-LLM-legible by design — point assistants at the page's `index.md` companion.
-
----
-
-## 10. The packages (architecture — for contributors/extenders)
-
-A pnpm + Turborepo monorepo. Most users never touch these, but each is published
-to npm and reusable.
-
-| Package | Role |
-| --- | --- |
-| `@clean-jsdoc-theme/utils` | Shared types, Zod schemas, the `SiteManifest` contract, slug rules, and **pure** opts-validation + build-report logic (network/zlib injected so it stays browser-safe). The setu↔dwar boundary lives here once. |
-| `@clean-jsdoc-theme/setu` | JSDoc doclets → `SiteManifest`. Emits MDX/Markdown only, **no HTML, no I/O**. Owns page generation, nav assembly, link resolution. |
-| `@clean-jsdoc-theme/rang` | Preact component library — SSR chrome, hydratable islands, the MDX element map, the island registry. **Owns every byte of page-shell HTML.** Tailwind utility classes over CSS variables. |
-| `@clean-jsdoc-theme/dwar` | `SiteManifest` → HTML/CSS/JS. A **pure** renderer: SSR pages, esbuild island bundle, CSS, separate Pagefind step. Consumes only the manifest; never re-reads doclets. |
-| `clean-jsdoc-theme` | The JSDoc theme entry — a thin CJS bridge (`publish()`) that does the file I/O and wires setu → dwar. |
-| `@clean-jsdoc-theme/typedoc` | The TypeDoc plugin — adapts reflections → doclets → the same setu → dwar core. ESM. |
-| `aadesh` / `bhasha` | Reserved stubs (CLI / i18n), v5.1+. |
-
-Boundary guarantees (don't violate when editing): **setu never imports dwar or
-rang** (one-way), **dwar.render() is pure** (the only disk touch is Pagefind),
-**dwar never re-reads doclets**, **slug rules and the boundary contract live once
-in utils**, and **chrome markup lives once in rang** (dwar's `SsrLayout` only wraps
-islands in `data-island` markers and fills rang's `Layout` slots).
-
-The 13 islands: `sidebar`, `mobile-nav`, `toc`, `toc-mobile`, `cmdk`, `code-tabs`,
-`copy-btn`, `copy-page`, `theme-toggle`, `settings`, `code-viewer`, `embed`,
-`tabs`. Each renders meaningful SSR HTML first, then progressively enhances.
-
-**Build commands:**
-
-```sh
-pnpm install
-pnpm build        # tsup per package (dwar compiles its Tailwind CSS first)
-pnpm build:docs   # generate every site (docs-site + examples)
-pnpm test         # vitest across utils / setu / rang / dwar
-pnpm typecheck
-pnpm lint
-```
-
-`examples/*` and `docs-site` consume the theme's **built `dist`**, so their `docs`
-script runs `build:theme` (turbo) first to rebuild the upstream graph. The
-canonical architecture doc is [`docs/ARCHITECTURE.md`](https://github.com/ankitskvmdam/clean-jsdoc-theme/blob/master/docs/ARCHITECTURE.md).
-
----
-
-## 11. Common gotchas & troubleshooting
-
-- **Descriptions render as raw text / Markdown not formatting (JSDoc):** you're
-  missing `plugins: ["plugins/markdown"]`. It's required.
-- **`@category` / `@order` / `@iframe` do nothing:** set
-  `tags.allowUnknownTags: true` in `jsdoc.json`. JSDoc strips unknown tags otherwise.
-- **A step's/tab's code block or list renders flat:** add **blank lines** around
-  the inner content — each body is re-parsed as Markdown.
-- **`@category Getting Started` made two nested groups:** spaces don't nest, only
-  `/` does. `Getting Started` is one flat group whose name contains a space. Use
-  `Core/Parsing` to nest.
-- **A guide group appears after Classes/Modules even though I listed it first:**
-  `docGroups` always appends doc groups after API sections — use `sectionOrder` to
-  interleave.
-- **Full-text search empty when opening `index.html` from disk:** Pagefind needs
-  HTTP. Serve the folder (`npx serve dist`).
-- **An embed didn't appear:** the URL must be `https://` or protocol-relative
-  `//`. `http://` and relative paths are dropped (with a warning).
-- **A page silently missing:** a page that fails to MDX-compile is skipped and
-  reported in `RenderResult.errors` (the bridge logs it) — check the build output;
-  it never aborts the whole build.
-- **A bad font name or unknown option only warned:** that's the default
-  (resilient). Use `strict: true` to fail the build instead.
-- **A doc's slug collides with an API/home/tutorial slug:** the doc is skipped and
-  logged (kind precedence: module > namespace > class > interface > mixin > typedef).
-
----
-
-## 12. Quick reference
+## 4. Quick reference
 
 ```jsonc
 // JSDoc: opts.* | TypeDoc: cleanJsdocTheme.*  (identical values)
@@ -541,11 +159,10 @@ canonical architecture doc is [`docs/ARCHITECTURE.md`](https://github.com/ankits
   copyPage, aiPrompt,
   strict, progress
 }
-// JSDoc-only, under templates.default.*:
-//   outputSourceFiles, sourceLinkToComment
+// JSDoc-only, under templates.default.*:  outputSourceFiles, sourceLinkToComment
 ```
 
-Authoring cheat sheet:
+Authoring (details in [`reference/authoring.md`](reference/authoring.md)):
 
 - Callout: `> [!TIP]` / `[!NOTE]` / `[!WARNING]` / `[!ERROR]` (+ aliases).
 - Steps: `<steps><step label="…">…blank-line-wrapped body…</step></steps>`.
@@ -554,82 +171,77 @@ Authoring cheat sheet:
 - Sidebar: `@category Core/Parsing order=1`, `@order N`, frontmatter `group`/`order`.
 - Cross-link: `{@link Symbol}`, `{@linkcode Symbol}`, `@see {@link Other}`.
 
+The two most common setup mistakes: missing `plugins/markdown` (JSDoc) and missing
+`tags.allowUnknownTags: true` (needed for `@category`/`@order`/`@iframe`). More in
+[`reference/troubleshooting.md`](reference/troubleshooting.md).
+
 ---
 
-## 13. Staying current
+## 5. Migrating from v4
 
-This skill and the theme both evolve. Keep the user current — but **do this with
-restraint**: check **at most once per session**, only when it's relevant (you're
-starting work with this skill, or the user asks about upgrading/updating), and
-**surface a result only when there's something actionable**. Never poll on every
-turn, never block the task on a check, and never nag — one short heads-up, then
-drop it unless the user engages.
+If the user is on **v4** (options nested under `opts.theme_opts.*`), that's a
+separate, focused job — use the dedicated **`migrate-v4-to-v5`** skill
+(`SKILLS/migrate-v4-to-v5/SKILL.md` in this repo). The headline: v5 reads options
+directly from `opts.*` (no `theme_opts` block), and most options were renamed or
+removed. The canonical map is the repo's `MIGRATION.md` + `migration-map.json`.
 
-You do not have a background timer; "periodically" here means *opportunistically,
-once per working session*, not a loop.
+---
 
-### Is this skill out of date?
+## 6. Staying current
 
-This file carries a `skill-revision: <date>` marker near the top. When relevant,
-fetch the published copy and compare its marker to this one:
+The skill and the theme both evolve. Keep the user current — but **with
+restraint**: check **at most once per session**, only when relevant (you're
+starting work with this skill, or the user asks about upgrading), and **surface a
+result only when there's something actionable**. Never poll on every turn, never
+block the task, never nag. You have no background timer — "periodically" here means
+*opportunistically, once per session*, not a loop.
+
+**Is this skill out of date?** This file carries a `skill-revision: <date>` marker.
+When relevant, fetch the published copy and compare:
 
 ```sh
 curl -fsSL https://raw.githubusercontent.com/ankitskvmdam/clean-jsdoc-theme/master/SKILLS/clean-jsdoc-theme/SKILL.md | grep -m1 skill-revision
 ```
 
-If the published revision is newer than the one you're running, tell the user a
-newer skill is available and **offer to update their copy** (overwrite the file
-they loaded it from — e.g. `.claude/skills/clean-jsdoc-theme/SKILL.md`). Don't
-overwrite without asking.
+If the published revision is newer, tell the user and **offer to update their
+copy** (the whole `clean-jsdoc-theme/` skill folder — it has `reference/` files,
+not just `SKILL.md`). Don't overwrite without asking.
 
-### Is the theme out of date?
-
-When setting up or upgrading, compare the installed version against the latest
-published one and mention it if behind:
+**Is the theme out of date?** When setting up or upgrading, compare installed vs
+latest and mention it if behind:
 
 ```sh
-# installed (JSDoc bridge / TypeDoc plugin)
-npm ls clean-jsdoc-theme @clean-jsdoc-theme/typedoc 2>/dev/null
-# latest on npm
-npm view clean-jsdoc-theme version
-npm view @clean-jsdoc-theme/typedoc version
+npm ls clean-jsdoc-theme @clean-jsdoc-theme/typedoc 2>/dev/null   # installed
+npm view clean-jsdoc-theme version                                # latest
 ```
 
-If a newer release exists, note it and the upgrade command (`npm i -D
-clean-jsdoc-theme@latest`), and point at the repo's `BREAKING_CHANGES.md` /
-`MIGRATION.md` for major bumps. Mention it once; let the user decide.
+If behind, note the upgrade (`npm i -D clean-jsdoc-theme@latest`) and point at
+`BREAKING_CHANGES.md` / `MIGRATION.md` for major bumps. Mention once; let the user decide.
 
 ---
 
-## 14. Proactively improve the docs
+## 7. Proactively improve the docs
 
-You know features the user may not — surface them. When you're helping author or
-review docs, watch for places where a theme-specific construct would read better
-than plain Markdown, and **suggest it** (briefly, with the exact syntax from §5/§7;
-don't rewrite everything unprompted). Good prompts to act on:
+You know features the user may not — surface them. When helping author or review
+docs, watch for places where a theme-specific construct reads better than plain
+Markdown and **suggest it** (briefly, with the exact syntax from
+[`reference/authoring.md`](reference/authoring.md); don't rewrite everything
+unprompted). Lead with the highest-impact one, keep it to a sentence or two, and
+let the user opt in.
 
-- **A note/warning written as plain text or bold** ("Note: …", "⚠️ be careful") →
-  offer a [callout](#callouts--github-style-alert-blockquotes)
+- **A note/warning as plain text or bold** ("Note: …", "⚠️ …") → a **callout**
   (`> [!NOTE]` / `[!WARNING]` / `[!TIP]`).
-- **A numbered install/setup walkthrough** (`1.` `2.` `3.`) → offer a
-  [`<steps>`](#steps--numbered-stepper-ssr-no-js) stepper.
-- **Per-tool / per-platform variants** (npm vs pnpm, JSDoc vs TypeDoc) shown as
-  separate code blocks → offer [`<tabs>`](#tabs--tabbed-view-ssr--a-light-enhancement-island),
-  with a shared `group` to sync them across the page.
-- **A linked CodePen / StackBlitz / demo** → offer an
-  [embed](#embeds--sandboxed-iframes--live-demos) (` ```iframe ` fence or `@iframe`).
-- **A long, flat sidebar, or symbols in the wrong section** → offer
-  [`@category` / `@order`](#5-authoring-rich-content) on the source symbols and
-  `group` / `order` frontmatter on guides, plus `sectionOrder` / `clubSidebarItems`
-  to shape the top level (§7).
-- **Cross-references written as bare text or code** (mentioning another class /
-  method) → offer `{@link Symbol}` so it becomes a real, resolved anchor.
-- **A class/method whose params or returns aren't documented** → offer the
-  `@param` / `@returns` tags so the generated tables (and the constructor
-  signature) fill in.
+- **A numbered install/setup walkthrough** → a **`<steps>`** stepper.
+- **Per-tool / per-platform variants** (npm vs pnpm, JSDoc vs TypeDoc) as separate
+  code blocks → **`<tabs>`** with a shared `group` to sync them.
+- **A linked CodePen / StackBlitz / demo** → an **embed** (` ```iframe ` / `@iframe`).
+- **A long, flat sidebar, or symbols in the wrong section** → **`@category` /
+  `@order`** on the symbols and `group` / `order` frontmatter on guides, plus
+  `sectionOrder` / `clubSidebarItems` to shape the top level.
+- **Cross-references written as bare text or code** → **`{@link Symbol}`** so it
+  becomes a real, resolved anchor.
+- **Undocumented params/returns** → the `@param` / `@returns` tags so the generated
+  tables (and the constructor signature) fill in.
 - **A project that cares about AI consumption** → remind them every page already
-  ships a companion `.md` and the `copyPage` actions, and that `aiPrompt` can
-  prime the open-in-LLM handoff.
-
-Lead with the highest-impact suggestion, keep it to a sentence or two, and let the
-user opt in rather than reformatting their docs wholesale.
+  ships a companion `.md` + the `copyPage` actions, and that `aiPrompt` primes the
+  open-in-LLM handoff.

--- a/SKILLS/clean-jsdoc-theme/reference/architecture.md
+++ b/SKILLS/clean-jsdoc-theme/reference/architecture.md
@@ -1,0 +1,40 @@
+# Architecture — for contributors / extenders
+
+A pnpm + Turborepo monorepo. Most theme *users* never touch these, but each is
+published to npm and reusable. Read this when working **on** the theme rather than
+**with** it.
+
+| Package | Role |
+| --- | --- |
+| `@clean-jsdoc-theme/utils` | Shared types, Zod schemas, the `SiteManifest` contract, slug rules, and **pure** opts-validation + build-report logic (network/zlib injected so it stays browser-safe). The setu↔dwar boundary lives here once. |
+| `@clean-jsdoc-theme/setu` | JSDoc doclets → `SiteManifest`. Emits MDX/Markdown only, **no HTML, no I/O**. Owns page generation, nav assembly, link resolution. |
+| `@clean-jsdoc-theme/rang` | Preact component library — SSR chrome, hydratable islands, the MDX element map, the island registry. **Owns every byte of page-shell HTML.** Tailwind utility classes over CSS variables. |
+| `@clean-jsdoc-theme/dwar` | `SiteManifest` → HTML/CSS/JS. A **pure** renderer: SSR pages, esbuild island bundle, CSS, separate Pagefind step. Consumes only the manifest; never re-reads doclets. |
+| `clean-jsdoc-theme` | The JSDoc theme entry — a thin CJS bridge (`publish()`) that does the file I/O and wires setu → dwar. |
+| `@clean-jsdoc-theme/typedoc` | The TypeDoc plugin — adapts reflections → doclets → the same setu → dwar core. ESM. |
+| `aadesh` / `bhasha` | Reserved stubs (CLI / i18n), v5.1+. |
+
+Boundary guarantees (don't violate when editing): **setu never imports dwar or
+rang** (one-way), **dwar.render() is pure** (the only disk touch is Pagefind),
+**dwar never re-reads doclets**, **slug rules and the boundary contract live once
+in utils**, and **chrome markup lives once in rang** (dwar's `SsrLayout` only wraps
+islands in `data-island` markers and fills rang's `Layout` slots).
+
+The 13 islands: `sidebar`, `mobile-nav`, `toc`, `toc-mobile`, `cmdk`, `code-tabs`,
+`copy-btn`, `copy-page`, `theme-toggle`, `settings`, `code-viewer`, `embed`,
+`tabs`. Each renders meaningful SSR HTML first, then progressively enhances.
+
+**Build commands:**
+
+```sh
+pnpm install
+pnpm build        # tsup per package (dwar compiles its Tailwind CSS first)
+pnpm build:docs   # generate every site (docs-site + examples)
+pnpm test         # vitest across utils / setu / rang / dwar
+pnpm typecheck
+pnpm lint
+```
+
+`examples/*` and `docs-site` consume the theme's **built `dist`**, so their `docs`
+script runs `build:theme` (turbo) first to rebuild the upstream graph. The
+canonical architecture doc is [`docs/ARCHITECTURE.md`](https://github.com/ankitskvmdam/clean-jsdoc-theme/blob/master/docs/ARCHITECTURE.md).

--- a/SKILLS/clean-jsdoc-theme/reference/authoring.md
+++ b/SKILLS/clean-jsdoc-theme/reference/authoring.md
@@ -1,0 +1,141 @@
+# Authoring rich content
+
+All of these work in **prose** (README, tutorials, the `docs` directory). Several
+also work directly inside **JSDoc/TypeDoc comment descriptions**. There is no
+dedicated block tag for steps/tabs/callouts — you write the same markup in either
+place and it flows through one converter.
+
+Contents: [Callouts](#callouts) · [Steps](#steps) · [Tabs](#tabs) ·
+[Embeds](#embeds) · [Custom doc-comment tags](#custom-doc-comment-tags).
+
+## Callouts
+
+GitHub-style alert blockquotes:
+
+```markdown
+> [!NOTE]
+> Useful information, even when skimming.
+```
+
+Four variants; markers are case-insensitive and several keywords fold onto each:
+
+| Marker | Variant |
+| --- | --- |
+| `[!INFO]` `[!NOTE]` `[!IMPORTANT]` | info (blue) |
+| `[!TIP]` `[!SUCCESS]` | tip (green) |
+| `[!WARNING]` `[!CAUTION]` | warning (amber) |
+| `[!ERROR]` `[!DANGER]` | error (red) |
+
+The marker must be the first thing in the blockquote; it's stripped from the
+body. Bodies are full Markdown and callouts promote at any depth (incl. inside
+list items). A `@deprecated` doc-comment tag **auto-emits** an error callout (with
+a kind-aware default sentence when no reason is given).
+
+## Steps
+
+Numbered stepper (SSR, no JS):
+
+```markdown
+<steps>
+
+<step label="Install">
+
+Add the package as a dev dependency.
+
+</step>
+
+<step label="Build">
+
+Run the build and open the output.
+
+</step>
+
+</steps>
+```
+
+`label` is optional. **Leave a blank line around each step's inner content** —
+each body is re-parsed as Markdown, so blank lines are what let fenced
+code/lists/nested containers parse. You can nest tabs, callouts, code, even
+another `<steps>` inside a step.
+
+## Tabs
+
+Tabbed view (SSR + a light enhancement island):
+
+```markdown
+<tabs group="pm">
+
+<tab label="npm">
+
+```sh
+npm install clean-jsdoc-theme
+```
+
+</tab>
+
+<tab label="pnpm">
+
+```sh
+pnpm add clean-jsdoc-theme
+```
+
+</tab>
+
+</tabs>
+```
+
+- `<tab label>` — button text (falls back to `Tab N`).
+- `<tab value>` — cross-block sync key; defaults to the normalized label, so
+  **identical labels sync for free**.
+- `<tabs group>` — opts the block into cross-block syncing: give multiple blocks
+  the same `group` and switching one switches all (persisted across visits).
+
+Same blank-line rule as steps.
+
+## Embeds
+
+Sandboxed iframes / live demos. Two authoring forms, **one config grammar**
+(`<url> key=value flag`):
+
+Prose fence:
+
+````markdown
+```iframe
+https://example.com/embed/demo title="Live demo" height=420
+```
+````
+
+Source-comment block tag (requires `tags.allowUnknownTags: true`):
+
+```js
+/** @iframe https://example.com/embed/demo title="Demo" aspectRatio=16/9 */
+```
+
+- **First token = URL.** Only `https://` or protocol-relative `//` URLs are
+  accepted; anything else is dropped with a warning.
+- Options: `title`, `width` (CSS, default `100%`), `height` (px, default `400`),
+  `aspectRatio` (e.g. `16/9`, preferred over height), `allow`, `sandbox`,
+  `clickToLoad` (poster instead of live iframe), `themed`.
+- `themed` is **on by default**: a `{theme}` token in the URL is swapped for
+  `light`/`dark`; else an author `theme-id` param wins; else `?theme-id=<theme>`
+  is appended. Opt out with `themed=false`. Both live and click-to-load work with
+  no JS (`<noscript>` fallback).
+
+## Custom doc-comment tags
+
+All three are **unknown tags** → require `tags.allowUnknownTags: true` in
+`jsdoc.json` (without it JSDoc strips them before the theme runs):
+
+- **`@category <path> [order=N]`** — put a symbol's page in an explicit sidebar
+  group. The group path is the **leading whitespace-separated tokens joined with
+  a single space** (so `@category Getting Started` is one flat group named
+  "Getting Started"); parsing switches to `key=value` options at the first token
+  containing `=`. A literal **`/` nests** (`Core/Parsing` → Core ▸ Parsing).
+  First `@category` wins.
+- **`@order N`** — within-group sort key for any symbol, including a plain
+  `@module`/`@class` in its kind section. When both are present,
+  `@category … order=` wins over a standalone `@order`.
+- **`@iframe`** — see [Embeds](#embeds) above.
+
+See [content-and-sidebar.md](content-and-sidebar.md) for how `@category`/`@order`
+feed the sidebar.

--- a/SKILLS/clean-jsdoc-theme/reference/configuration.md
+++ b/SKILLS/clean-jsdoc-theme/reference/configuration.md
@@ -1,0 +1,84 @@
+# Configuration reference
+
+Every theme option. Identical for both tools — only the namespace differs:
+**`opts.*`** (JSDoc) vs **`cleanJsdocTheme.*`** (TypeDoc).
+
+> Unknown / misspelled keys only **warn** (with a "did you mean?" hint) and the
+> build continues. Set `strict: true` to escalate warnings to hard errors.
+
+Contents: [Site & identity](#site--identity) · [Content sources](#content-sources) ·
+[Sidebar & navigation](#sidebar--navigation) · [Appearance & assets](#appearance--assets) ·
+[LLM & copy-page](#llm--copy-page) · [Build](#build) ·
+[JSDoc-only options](#jsdoc-only-under-templatesdefault-not-opts) ·
+[Asset handling](#asset-handling-automatic--no-config).
+
+## Site & identity
+
+| Option | Type | Notes |
+| --- | --- | --- |
+| `siteName` | string \| logo set | Header title. Logo set: `{ light, dark, default, alt }` (URLs or local paths; dark/light swap via CSS). Defaults to the package `name`. Local logos are copied to content-hashed `_assets/`. |
+| `basePath` | string | Root path prefixed onto every internal link/asset, for sub-path hosting (`/my-lib`). Default `""`. |
+
+## Content sources
+
+| Option | Type | Notes |
+| --- | --- | --- |
+| `readme` | path | Markdown rendered as the **home page** (slug `""`). A root `docs/index.md` overrides it. |
+| `docs` | dir path | A directory of hand-written `.md`/`.markdown`/`.html` guides → prose pages. Folder layout drives URL + sidebar group (see [content-and-sidebar.md](content-and-sidebar.md)). |
+| `docGroups` | string[] | Display order of top-level **doc** groups in the sidebar. |
+| `defaultDocGroup` | string | Group a doc lands in when it declares none. |
+| `tutorials` | dir path | JSDoc `--tutorials` tree → guide pages under a "Tutorials" group (sub-tutorials nest). Equivalent to JSDoc's `-u`. |
+
+## Sidebar & navigation
+
+See [content-and-sidebar.md](content-and-sidebar.md) for the full ordering model.
+
+| Option | Type | Notes |
+| --- | --- | --- |
+| `sectionOrder` | string[] | Order of **all** top-level sections (kind labels AND doc/category groups). Listed first, rest appended. For kind labels it's also a filter — an **omitted kind label is dropped**; category/doc groups are never dropped by omission. |
+| `clubSidebarItems` | boolean | Collapse related entries under a shared collapsible parent, grouped by the path segment before the first `/`. Default `false`. Applies **only** to kind-label fallback buckets, never to `@category`-built groups. |
+| `menu` | entry[] | Custom links pinned above the sidebar. Each: `{ title, link (or href), id?, icon? }`. `icon` is `lucide:<name>` or `simpleicons:<name>` (CDN-loaded). When set, `menu` owns the auto Home/Source links (suppressed unless you list `{ id: "home" }` / `{ id: "source" }`). |
+
+## Appearance & assets
+
+| Option | Type | Notes |
+| --- | --- | --- |
+| `fonts` | `{ heading?, body?, mono? }` | `heading`/`body` are Google Font family names (loaded for you, existence-checked at build); `mono` is a CSS font stack. |
+| `colors` | color map | Light-mode palette; merges **per key** over the built-in palette. Keys: `bg`, `bgMuted`, `fg`, `fgMuted`, `accent`, `accentFg`, `border`. Any valid CSS color (ships OKLCH). |
+| `darkColors` | color map | Same keys, emitted under `[data-theme="dark"]`. Omit it and dark mode falls back to a sensible bg/fg swap. |
+| `customCss` / `customJs` | string | Inline CSS/JS injected on every page. CSS loads **after** the theme stylesheet (overrides win); JS runs **last**. |
+| `customCssFile` / `customJsFile` | path | Same, read from disk; copied to content-hashed `_assets/`. |
+| `hashCustomAssets` | boolean | Content-hash custom-asset filenames for cache-busting. Default `true`. |
+
+## LLM & copy-page
+
+| Option | Type | Notes |
+| --- | --- | --- |
+| `copyPage` | boolean \| `{ enabled, actions }` | The per-page copy / open-in-LLM button (content pages only). `actions` ⊂ `copy`, `view`, `claude`, `chatgpt`, `perplexity`. On by default with all actions. |
+| `aiPrompt` | string | Instruction prepended when a page is handed to an LLM via the open-in actions. |
+
+## Build
+
+| Option | Type | Notes |
+| --- | --- | --- |
+| `strict` | boolean | Escalate option diagnostics (bad font, unknown key) from warnings to hard errors. Default `false`. |
+| `progress` | boolean | Toggle per-stage build spinners. Default `true`. |
+
+## JSDoc-only (under `templates.default`, NOT `opts`)
+
+```json5
+templates: { default: { outputSourceFiles: false, sourceLinkToComment: true } }
+```
+
+- `outputSourceFiles` (default `true`) — generate the source-file viewer pages
+  and `Source: file:line` links.
+- `sourceLinkToComment` (default `false`) — land a `Source:` link on the doc
+  **comment** instead of the **declaration**.
+
+## Asset handling (automatic — no config)
+
+Any image referenced from docs/README with a relative or root-relative path is
+copied into `_assets/` under a **content-hashed** name and the ref is rewritten.
+`.svg` files are **inlined** into the page so their own `[data-theme="dark"]`
+styles can follow the in-page theme toggle (an `<img>` SVG can't). External
+(`https://`) and `data:` URLs are left untouched.

--- a/SKILLS/clean-jsdoc-theme/reference/content-and-sidebar.md
+++ b/SKILLS/clean-jsdoc-theme/reference/content-and-sidebar.md
@@ -1,0 +1,89 @@
+# Content pages, the sidebar model & cross-references
+
+Contents: [The docs directory & frontmatter](#the-docs-directory--frontmatter) ·
+[The sidebar model](#the-sidebar-model) ·
+[Cross-references & source links](#cross-references--source-links).
+
+## The docs directory & frontmatter
+
+Point `opts.docs` at a directory. Each `.md`/`.markdown`/`.html`/`.htm` file
+becomes one page; `node_modules`, `.git`, and dotfiles are skipped. The filesystem
+drives the URL and sidebar group:
+
+| Field | Derivation (first match wins) |
+| --- | --- |
+| `slug` | frontmatter `slug` → slugified relative path with **no prefix**; `index` → `""` |
+| `title` | frontmatter `title` → humanized basename |
+| `group` | frontmatter `group` → humanized **directory** path → `defaultDocGroup` |
+| `order` | frontmatter `order` |
+| `hidden` | frontmatter `hidden` (default `false`; hidden = rendered but kept out of the sidebar) |
+
+So `guides/Advanced Setup.md` → `/guides/advanced-setup` in group **Guides**;
+`guides/setup/install.md` → nested group **Guides/Setup**. A root `index.md` is
+the home page and **overrides `readme`**.
+
+Frontmatter is a leading `---` block of **flat `key: value` scalars only** — no
+nested YAML, lists, or multi-line values. A malformed/unterminated block is
+treated as no frontmatter.
+
+```markdown
+---
+title: Advanced Setup
+group: Guides
+order: 2
+slug: guides/advanced
+hidden: false
+---
+
+# Advanced Setup
+```
+
+## The sidebar model
+
+One engine, several levers. Every navigable entry — API symbol, guide page,
+tutorial — carries a **`group` path** (the bold top-level title, optionally a
+`/`-nested branch) and an optional **`order`** (within-group sort key). That single
+abstraction is why a guide and a class can share a sidebar group.
+
+Where they come from:
+
+| Source | `group` | `order` |
+| --- | --- | --- |
+| API symbol | `@category`, else kind label (Classes, …) | `@category … order=`, else `@order` |
+| Guide page | frontmatter `group`, else directory, else `defaultDocGroup` | frontmatter `order` |
+| Tutorial | the tutorial hierarchy (`Tutorials/<parent>/…`) | resolved tree order |
+
+The levers:
+
+1. **`@category` / `@order`** (source tags — see [authoring.md](authoring.md)) —
+   group and order API symbols.
+2. **`/`-paths nest** — first segment = bold top-level title, deeper segments =
+   collapsible branches. Works from `@category`, frontmatter `group`, or directory.
+3. **Leaf-vs-branch order:** within a level, sort by effective order ascending (a
+   branch's effective order = the **min `order` of any page inside it**, so
+   `order=1` on one nested page floats its whole subgroup up); ties → leaves
+   before branches; then first-seen. No-order entries sort last, then alphabetical.
+4. **`clubSidebarItems`** — collapse kind-label buckets by the prefix before the
+   first `/` in their label (`queue`, `queue/Queue` → a `queue` parent; the bare
+   `queue` becomes an `index` child). Mutually exclusive with `@category` nesting.
+5. **`sectionOrder`** — order the top-level sections (kind labels + group names in
+   one list). Omitted kind labels are dropped; category/doc groups are appended.
+6. **`docGroups` / `defaultDocGroup`** — order doc-group sections (appended after
+   API sections unless also named in `sectionOrder`); fallback group for ungrouped docs.
+7. **`menu`** — a top region above the sections, each with an icon.
+
+Mixing guides interleaved with API kinds (Classes between two prose groups) needs
+`sectionOrder`; `docGroups` alone always appends doc groups after API sections.
+
+## Cross-references & source links
+
+- **`{@link}` / `{@linkcode}` / `{@linkplain}`** inline tags and **`@see`** block
+  tags resolve to real cross-page anchors. setu builds a link registry from the
+  pages it actually generates (two-pass, so forward references resolve), rewriting
+  namepaths → page-slug + `#member` anchor.
+- External URLs (`http(s)://`, `mailto:`) link directly (and `https://` opens in a
+  new tab). Unresolved namepaths fall back to inline code (the look JSDoc text had).
+- A **bare short name** (`{@link BaseEntity}`) resolves only when unambiguous
+  across the whole registry — ambiguous names refuse to guess.
+- Every documented member gets a `Source: file:line` link (default on) landing on
+  the declaration line; the source-viewer page opens Monaco to that exact line.

--- a/SKILLS/clean-jsdoc-theme/reference/troubleshooting.md
+++ b/SKILLS/clean-jsdoc-theme/reference/troubleshooting.md
@@ -1,0 +1,25 @@
+# Troubleshooting & common gotchas
+
+- **Descriptions render as raw text / Markdown not formatting (JSDoc):** you're
+  missing `plugins: ["plugins/markdown"]`. It's required.
+- **`@category` / `@order` / `@iframe` do nothing:** set
+  `tags.allowUnknownTags: true` in `jsdoc.json`. JSDoc strips unknown tags otherwise.
+- **A step's/tab's code block or list renders flat:** add **blank lines** around
+  the inner content — each body is re-parsed as Markdown.
+- **`@category Getting Started` made two nested groups:** spaces don't nest, only
+  `/` does. `Getting Started` is one flat group whose name contains a space. Use
+  `Core/Parsing` to nest.
+- **A guide group appears after Classes/Modules even though I listed it first:**
+  `docGroups` always appends doc groups after API sections — use `sectionOrder` to
+  interleave.
+- **Full-text search empty when opening `index.html` from disk:** Pagefind needs
+  HTTP. Serve the folder (`npx serve dist`).
+- **An embed didn't appear:** the URL must be `https://` or protocol-relative
+  `//`. `http://` and relative paths are dropped (with a warning).
+- **A page silently missing:** a page that fails to MDX-compile is skipped and
+  reported in `RenderResult.errors` (the bridge logs it) — check the build output;
+  it never aborts the whole build.
+- **A bad font name or unknown option only warned:** that's the default
+  (resilient). Use `strict: true` to fail the build instead.
+- **A doc's slug collides with an API/home/tutorial slug:** the doc is skipped and
+  logged (kind precedence: module > namespace > class > interface > mixin > typedef).

--- a/SKILLS/migrate-v4-to-v5/SKILL.md
+++ b/SKILLS/migrate-v4-to-v5/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: clean-jsdoc-theme-migrate-v4-to-v5
+name: migrate-v4-to-v5
 description: >-
   Step-by-step procedure to migrate a project from clean-jsdoc-theme v4 to v5.
   Use when a user wants to upgrade, migrate, or port their JSDoc config from

--- a/docs-site/docs/theme/llm-skill.md
+++ b/docs-site/docs/theme/llm-skill.md
@@ -65,15 +65,19 @@ nest a [`@category`](/authoring/custom-tags) path when only `/` does.
 
 <step label="Download it">
 
-Grab the raw file from the repository:
+The skill is a **folder** —
+[`SKILLS/clean-jsdoc-theme/`](https://github.com/ankitskvmdam/clean-jsdoc-theme/tree/master/SKILLS/clean-jsdoc-theme) —
+a lean `SKILL.md` plus on-demand `reference/` files (the assistant reads only the
+slice it needs). Grab the whole folder:
 
 ```sh
-curl -O https://raw.githubusercontent.com/ankitskvmdam/clean-jsdoc-theme/master/SKILLS/clean-jsdoc-theme/SKILL.md
+npx degit ankitskvmdam/clean-jsdoc-theme/SKILLS/clean-jsdoc-theme clean-jsdoc-theme
 ```
 
-Or open
+Or just open
 [`SKILL.md` on GitHub](https://github.com/ankitskvmdam/clean-jsdoc-theme/blob/master/SKILLS/clean-jsdoc-theme/SKILL.md)
-and copy it.
+and copy it — the `SKILL.md` is self-sufficient for most questions and links to
+the reference files for the rest.
 
 </step>
 
@@ -85,16 +89,15 @@ Pick whichever matches your setup:
 
 <tab label="Claude Code / agents">
 
-It's a ready-to-use **skill**. Drop it into your project (or user) skills
-directory so the agent loads it on demand:
+It's a ready-to-use **skill**. Drop the folder into your project (or user) skills
+directory so the agent loads it — and its `reference/` files — on demand:
 
 ```sh
-mkdir -p .claude/skills/clean-jsdoc-theme
-mv SKILL.md .claude/skills/clean-jsdoc-theme/SKILL.md
+npx degit ankitskvmdam/clean-jsdoc-theme/SKILLS/clean-jsdoc-theme .claude/skills/clean-jsdoc-theme
 ```
 
-The `name` / `description` frontmatter is what lets the agent decide when to
-apply it.
+The `name` / `description` frontmatter is what lets the agent decide when to apply
+it; the `SKILL.md` then pulls in the matching `reference/` file per task.
 
 </tab>
 


### PR DESCRIPTION
Brings the downloadable agent skills in line with Anthropic's published [Skill authoring best practices](https://platform.claude.com/docs/en/agents-and-tools/agent-skills/best-practices). Two commits:

### Split the umbrella skill into progressive-disclosure reference files
The umbrella `SKILLS/clean-jsdoc-theme/SKILL.md` had grown to ~635 lines — over the "keep SKILL.md under ~500 lines and push detail into on-demand files" guidance. It's now a lean ~247-line operating guide (mental model, setup, what-becomes-a-page, quick reference, and the staying-current / improve-docs behaviour) that routes each task to a focused `reference/` file loaded only when needed:

- `reference/configuration.md` — the full options reference
- `reference/authoring.md` — callouts / steps / tabs / embeds / custom tags
- `reference/content-and-sidebar.md` — docs dir + frontmatter, the sidebar model, cross-references
- `reference/architecture.md` — the packages (for contributors)
- `reference/troubleshooting.md` — gotchas

Each >100-line reference file has a table of contents; references are one level deep; links use forward slashes. Also updated the docs-site "Use with an LLM" download/install steps to fetch the whole folder via `degit` (single-file `curl` would miss the `reference/` files).

### Match the migration skill name to its folder
`SKILLS/migrate-v4-to-v5/SKILL.md` had `name: clean-jsdoc-theme-migrate-v4-to-v5` while its folder is `migrate-v4-to-v5`; best practice is for the two to match. Renamed to `migrate-v4-to-v5` (consistent with the umbrella skill being just `clean-jsdoc-theme`).

No functional/code changes — docs + skill content only.