### PR TITLE
release: v5.0.0-alpha.4

### DIFF
--- a/.changeset/alpha-4-localization.md
+++ b/.changeset/alpha-4-localization.md
@@ -1,0 +1,39 @@
+---
+'clean-jsdoc-theme': minor
+'@clean-jsdoc-theme/utils': minor
+'@clean-jsdoc-theme/setu': minor
+'@clean-jsdoc-theme/rang': minor
+'@clean-jsdoc-theme/dwar': minor
+'@clean-jsdoc-theme/aadesh': minor
+'@clean-jsdoc-theme/bhasha': minor
+'@clean-jsdoc-theme/typedoc': minor
+---
+
+Localization (i18n), prompt-to-file, Unicode anchors, and polish.
+
+- **Multi-language documentation.** A new localization pipeline renders one static
+  site per locale (the default unprefixed, others under `/<locale>`) with a header
+  language switcher, `hreflang` alternates, and per-language fonts. Two new
+  packages drive it: **`@clean-jsdoc-theme/bhasha`** (the pure, browser-safe i18n
+  core — chrome catalog, the `t` translator + fallback chain, `LanguageProvider`,
+  and the API-slot key/hash scheme) and **`@clean-jsdoc-theme/aadesh`** (the
+  `clean-jsdoc` CLI: `extract` / `prompt` / `validate` / `build`, plus an
+  interactive menu). Translatable content spans UI chrome, API
+  descriptions/summaries/example captions/parameter + return descriptions, and
+  prose (a per-locale `README.<locale>.md` home and a `docs.<locale>/` overlay).
+  Opt in with `opts.locales` / `opts.defaultLocale`; a build with no locales stays
+  byte-identical. The TypeDoc bridge supports *extract* today; the localized
+  *build* is JSDoc-only for now.
+- **`clean-jsdoc prompt` writes files.** The LLM translation prompt is now written
+  to Markdown files under `clean-jsdoc-theme-artifacts/locales/prompts/` (chunked,
+  git-ignored, regenerated each run) instead of being dumped to the console — so
+  you can paste or upload each file straight into an LLM.
+- **Unicode-aware heading anchors.** `slugifyHeading` / `slugifyPath` /
+  `slugifySourcePath` now keep non-ASCII letters (and recompose to NFC), so Hindi,
+  Japanese, and CJK headings get meaningful anchors, a working TOC, and valid
+  `#fragment` links. Latin accent folding (`café → cafe`) is preserved.
+- **Sidebar TOC fix.** The active TOC entry is scrolled into view on long tables
+  of contents.
+- **Maintenance.** Package version constants are derived from `package.json` at
+  build time (no more drift), and the package READMEs were refreshed to match the
+  current code.

--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -12,11 +12,13 @@
     "@clean-jsdoc-theme/rang": "5.0.0-alpha.0",
     "@clean-jsdoc-theme/setu": "5.0.0-alpha.0",
     "@clean-jsdoc-theme/typedoc": "5.0.0-alpha.0",
-    "@clean-jsdoc-theme/utils": "5.0.0-alpha.0"
+    "@clean-jsdoc-theme/utils": "5.0.0-alpha.0",
+    "example-with-i18n": "0.0.0"
   },
   "changesets": [
     "alpha-2-assets-colors-tabs",
     "alpha-3-search-callouts-tutorials",
+    "alpha-4-localization",
     "curvy-bottles-throw"
   ]
 }

--- a/packages/aadesh/CHANGELOG.md
+++ b/packages/aadesh/CHANGELOG.md
@@ -1,5 +1,44 @@
 # @clean-jsdoc-theme/aadesh
 
+## 5.0.0-alpha.4
+
+### Minor Changes
+
+- Localization (i18n), prompt-to-file, Unicode anchors, and polish.
+  - **Multi-language documentation.** A new localization pipeline renders one static
+    site per locale (the default unprefixed, others under `/<locale>`) with a header
+    language switcher, `hreflang` alternates, and per-language fonts. Two new
+    packages drive it: **`@clean-jsdoc-theme/bhasha`** (the pure, browser-safe i18n
+    core — chrome catalog, the `t` translator + fallback chain, `LanguageProvider`,
+    and the API-slot key/hash scheme) and **`@clean-jsdoc-theme/aadesh`** (the
+    `clean-jsdoc` CLI: `extract` / `prompt` / `validate` / `build`, plus an
+    interactive menu). Translatable content spans UI chrome, API
+    descriptions/summaries/example captions/parameter + return descriptions, and
+    prose (a per-locale `README.<locale>.md` home and a `docs.<locale>/` overlay).
+    Opt in with `opts.locales` / `opts.defaultLocale`; a build with no locales stays
+    byte-identical. The TypeDoc bridge supports _extract_ today; the localized
+    _build_ is JSDoc-only for now.
+  - **`clean-jsdoc prompt` writes files.** The LLM translation prompt is now written
+    to Markdown files under `clean-jsdoc-theme-artifacts/locales/prompts/` (chunked,
+    git-ignored, regenerated each run) instead of being dumped to the console — so
+    you can paste or upload each file straight into an LLM.
+  - **Unicode-aware heading anchors.** `slugifyHeading` / `slugifyPath` /
+    `slugifySourcePath` now keep non-ASCII letters (and recompose to NFC), so Hindi,
+    Japanese, and CJK headings get meaningful anchors, a working TOC, and valid
+    `#fragment` links. Latin accent folding (`café → cafe`) is preserved.
+  - **Sidebar TOC fix.** The active TOC entry is scrolled into view on long tables
+    of contents.
+  - **Maintenance.** Package version constants are derived from `package.json` at
+    build time (no more drift), and the package READMEs were refreshed to match the
+    current code.
+
+### Patch Changes
+
+- Updated dependencies
+  - @clean-jsdoc-theme/utils@5.0.0-alpha.4
+  - @clean-jsdoc-theme/setu@5.0.0-alpha.4
+  - @clean-jsdoc-theme/bhasha@5.0.0-alpha.4
+
 ## 5.0.0-alpha.3
 
 ### Minor Changes

--- a/packages/aadesh/package.json
+++ b/packages/aadesh/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clean-jsdoc-theme/aadesh",
-  "version": "5.0.0-alpha.3",
+  "version": "5.0.0-alpha.4",
   "description": "CLI for clean-jsdoc-theme i18n and build workflows",
   "type": "module",
   "bin": {

--- a/packages/bhasha/CHANGELOG.md
+++ b/packages/bhasha/CHANGELOG.md
@@ -1,5 +1,42 @@
 # @clean-jsdoc-theme/bhasha
 
+## 5.0.0-alpha.4
+
+### Minor Changes
+
+- Localization (i18n), prompt-to-file, Unicode anchors, and polish.
+  - **Multi-language documentation.** A new localization pipeline renders one static
+    site per locale (the default unprefixed, others under `/<locale>`) with a header
+    language switcher, `hreflang` alternates, and per-language fonts. Two new
+    packages drive it: **`@clean-jsdoc-theme/bhasha`** (the pure, browser-safe i18n
+    core — chrome catalog, the `t` translator + fallback chain, `LanguageProvider`,
+    and the API-slot key/hash scheme) and **`@clean-jsdoc-theme/aadesh`** (the
+    `clean-jsdoc` CLI: `extract` / `prompt` / `validate` / `build`, plus an
+    interactive menu). Translatable content spans UI chrome, API
+    descriptions/summaries/example captions/parameter + return descriptions, and
+    prose (a per-locale `README.<locale>.md` home and a `docs.<locale>/` overlay).
+    Opt in with `opts.locales` / `opts.defaultLocale`; a build with no locales stays
+    byte-identical. The TypeDoc bridge supports _extract_ today; the localized
+    _build_ is JSDoc-only for now.
+  - **`clean-jsdoc prompt` writes files.** The LLM translation prompt is now written
+    to Markdown files under `clean-jsdoc-theme-artifacts/locales/prompts/` (chunked,
+    git-ignored, regenerated each run) instead of being dumped to the console — so
+    you can paste or upload each file straight into an LLM.
+  - **Unicode-aware heading anchors.** `slugifyHeading` / `slugifyPath` /
+    `slugifySourcePath` now keep non-ASCII letters (and recompose to NFC), so Hindi,
+    Japanese, and CJK headings get meaningful anchors, a working TOC, and valid
+    `#fragment` links. Latin accent folding (`café → cafe`) is preserved.
+  - **Sidebar TOC fix.** The active TOC entry is scrolled into view on long tables
+    of contents.
+  - **Maintenance.** Package version constants are derived from `package.json` at
+    build time (no more drift), and the package READMEs were refreshed to match the
+    current code.
+
+### Patch Changes
+
+- Updated dependencies
+  - @clean-jsdoc-theme/utils@5.0.0-alpha.4
+
 ## 5.0.0-alpha.3
 
 ### Minor Changes

--- a/packages/bhasha/package.json
+++ b/packages/bhasha/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clean-jsdoc-theme/bhasha",
-  "version": "5.0.0-alpha.3",
+  "version": "5.0.0-alpha.4",
   "description": "Pure, browser-safe i18n core for clean-jsdoc-theme (catalog, t, provider, key scheme, validation)",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/clean-jsdoc-theme/CHANGELOG.md
+++ b/packages/clean-jsdoc-theme/CHANGELOG.md
@@ -1,5 +1,46 @@
 # clean-jsdoc-theme
 
+## 5.0.0-alpha.4
+
+### Minor Changes
+
+- Localization (i18n), prompt-to-file, Unicode anchors, and polish.
+  - **Multi-language documentation.** A new localization pipeline renders one static
+    site per locale (the default unprefixed, others under `/<locale>`) with a header
+    language switcher, `hreflang` alternates, and per-language fonts. Two new
+    packages drive it: **`@clean-jsdoc-theme/bhasha`** (the pure, browser-safe i18n
+    core — chrome catalog, the `t` translator + fallback chain, `LanguageProvider`,
+    and the API-slot key/hash scheme) and **`@clean-jsdoc-theme/aadesh`** (the
+    `clean-jsdoc` CLI: `extract` / `prompt` / `validate` / `build`, plus an
+    interactive menu). Translatable content spans UI chrome, API
+    descriptions/summaries/example captions/parameter + return descriptions, and
+    prose (a per-locale `README.<locale>.md` home and a `docs.<locale>/` overlay).
+    Opt in with `opts.locales` / `opts.defaultLocale`; a build with no locales stays
+    byte-identical. The TypeDoc bridge supports _extract_ today; the localized
+    _build_ is JSDoc-only for now.
+  - **`clean-jsdoc prompt` writes files.** The LLM translation prompt is now written
+    to Markdown files under `clean-jsdoc-theme-artifacts/locales/prompts/` (chunked,
+    git-ignored, regenerated each run) instead of being dumped to the console — so
+    you can paste or upload each file straight into an LLM.
+  - **Unicode-aware heading anchors.** `slugifyHeading` / `slugifyPath` /
+    `slugifySourcePath` now keep non-ASCII letters (and recompose to NFC), so Hindi,
+    Japanese, and CJK headings get meaningful anchors, a working TOC, and valid
+    `#fragment` links. Latin accent folding (`café → cafe`) is preserved.
+  - **Sidebar TOC fix.** The active TOC entry is scrolled into view on long tables
+    of contents.
+  - **Maintenance.** Package version constants are derived from `package.json` at
+    build time (no more drift), and the package READMEs were refreshed to match the
+    current code.
+
+### Patch Changes
+
+- Updated dependencies
+  - @clean-jsdoc-theme/utils@5.0.0-alpha.4
+  - @clean-jsdoc-theme/setu@5.0.0-alpha.4
+  - @clean-jsdoc-theme/rang@5.0.0-alpha.4
+  - @clean-jsdoc-theme/dwar@5.0.0-alpha.4
+  - @clean-jsdoc-theme/bhasha@5.0.0-alpha.4
+
 ## 5.0.0-alpha.3
 
 ### Minor Changes

--- a/packages/clean-jsdoc-theme/package.json
+++ b/packages/clean-jsdoc-theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clean-jsdoc-theme",
-  "version": "5.0.0-alpha.3",
+  "version": "5.0.0-alpha.4",
   "description": "A modern, markdown-first JSDoc theme with i18n support",
   "main": "./dist/publish.js",
   "types": "./dist/publish.d.ts",

--- a/packages/dwar/CHANGELOG.md
+++ b/packages/dwar/CHANGELOG.md
@@ -1,5 +1,44 @@
 # @clean-jsdoc-theme/dwar
 
+## 5.0.0-alpha.4
+
+### Minor Changes
+
+- Localization (i18n), prompt-to-file, Unicode anchors, and polish.
+  - **Multi-language documentation.** A new localization pipeline renders one static
+    site per locale (the default unprefixed, others under `/<locale>`) with a header
+    language switcher, `hreflang` alternates, and per-language fonts. Two new
+    packages drive it: **`@clean-jsdoc-theme/bhasha`** (the pure, browser-safe i18n
+    core — chrome catalog, the `t` translator + fallback chain, `LanguageProvider`,
+    and the API-slot key/hash scheme) and **`@clean-jsdoc-theme/aadesh`** (the
+    `clean-jsdoc` CLI: `extract` / `prompt` / `validate` / `build`, plus an
+    interactive menu). Translatable content spans UI chrome, API
+    descriptions/summaries/example captions/parameter + return descriptions, and
+    prose (a per-locale `README.<locale>.md` home and a `docs.<locale>/` overlay).
+    Opt in with `opts.locales` / `opts.defaultLocale`; a build with no locales stays
+    byte-identical. The TypeDoc bridge supports _extract_ today; the localized
+    _build_ is JSDoc-only for now.
+  - **`clean-jsdoc prompt` writes files.** The LLM translation prompt is now written
+    to Markdown files under `clean-jsdoc-theme-artifacts/locales/prompts/` (chunked,
+    git-ignored, regenerated each run) instead of being dumped to the console — so
+    you can paste or upload each file straight into an LLM.
+  - **Unicode-aware heading anchors.** `slugifyHeading` / `slugifyPath` /
+    `slugifySourcePath` now keep non-ASCII letters (and recompose to NFC), so Hindi,
+    Japanese, and CJK headings get meaningful anchors, a working TOC, and valid
+    `#fragment` links. Latin accent folding (`café → cafe`) is preserved.
+  - **Sidebar TOC fix.** The active TOC entry is scrolled into view on long tables
+    of contents.
+  - **Maintenance.** Package version constants are derived from `package.json` at
+    build time (no more drift), and the package READMEs were refreshed to match the
+    current code.
+
+### Patch Changes
+
+- Updated dependencies
+  - @clean-jsdoc-theme/utils@5.0.0-alpha.4
+  - @clean-jsdoc-theme/setu@5.0.0-alpha.4
+  - @clean-jsdoc-theme/rang@5.0.0-alpha.4
+
 ## 5.0.0-alpha.3
 
 ### Minor Changes

--- a/packages/dwar/package.json
+++ b/packages/dwar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clean-jsdoc-theme/dwar",
-  "version": "5.0.0-alpha.3",
+  "version": "5.0.0-alpha.4",
   "description": "Pure SiteManifest → HTML/CSS/JS renderer for clean-jsdoc-theme",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/rang/CHANGELOG.md
+++ b/packages/rang/CHANGELOG.md
@@ -1,5 +1,43 @@
 # @clean-jsdoc-theme/rang
 
+## 5.0.0-alpha.4
+
+### Minor Changes
+
+- Localization (i18n), prompt-to-file, Unicode anchors, and polish.
+  - **Multi-language documentation.** A new localization pipeline renders one static
+    site per locale (the default unprefixed, others under `/<locale>`) with a header
+    language switcher, `hreflang` alternates, and per-language fonts. Two new
+    packages drive it: **`@clean-jsdoc-theme/bhasha`** (the pure, browser-safe i18n
+    core — chrome catalog, the `t` translator + fallback chain, `LanguageProvider`,
+    and the API-slot key/hash scheme) and **`@clean-jsdoc-theme/aadesh`** (the
+    `clean-jsdoc` CLI: `extract` / `prompt` / `validate` / `build`, plus an
+    interactive menu). Translatable content spans UI chrome, API
+    descriptions/summaries/example captions/parameter + return descriptions, and
+    prose (a per-locale `README.<locale>.md` home and a `docs.<locale>/` overlay).
+    Opt in with `opts.locales` / `opts.defaultLocale`; a build with no locales stays
+    byte-identical. The TypeDoc bridge supports _extract_ today; the localized
+    _build_ is JSDoc-only for now.
+  - **`clean-jsdoc prompt` writes files.** The LLM translation prompt is now written
+    to Markdown files under `clean-jsdoc-theme-artifacts/locales/prompts/` (chunked,
+    git-ignored, regenerated each run) instead of being dumped to the console — so
+    you can paste or upload each file straight into an LLM.
+  - **Unicode-aware heading anchors.** `slugifyHeading` / `slugifyPath` /
+    `slugifySourcePath` now keep non-ASCII letters (and recompose to NFC), so Hindi,
+    Japanese, and CJK headings get meaningful anchors, a working TOC, and valid
+    `#fragment` links. Latin accent folding (`café → cafe`) is preserved.
+  - **Sidebar TOC fix.** The active TOC entry is scrolled into view on long tables
+    of contents.
+  - **Maintenance.** Package version constants are derived from `package.json` at
+    build time (no more drift), and the package READMEs were refreshed to match the
+    current code.
+
+### Patch Changes
+
+- Updated dependencies
+  - @clean-jsdoc-theme/utils@5.0.0-alpha.4
+  - @clean-jsdoc-theme/bhasha@5.0.0-alpha.4
+
 ## 5.0.0-alpha.3
 
 ### Minor Changes

--- a/packages/rang/package.json
+++ b/packages/rang/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clean-jsdoc-theme/rang",
-  "version": "5.0.0-alpha.3",
+  "version": "5.0.0-alpha.4",
   "description": "Preact components, MDX component map, and island registry for clean-jsdoc-theme",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/setu/CHANGELOG.md
+++ b/packages/setu/CHANGELOG.md
@@ -1,5 +1,43 @@
 # @clean-jsdoc-theme/setu
 
+## 5.0.0-alpha.4
+
+### Minor Changes
+
+- Localization (i18n), prompt-to-file, Unicode anchors, and polish.
+  - **Multi-language documentation.** A new localization pipeline renders one static
+    site per locale (the default unprefixed, others under `/<locale>`) with a header
+    language switcher, `hreflang` alternates, and per-language fonts. Two new
+    packages drive it: **`@clean-jsdoc-theme/bhasha`** (the pure, browser-safe i18n
+    core — chrome catalog, the `t` translator + fallback chain, `LanguageProvider`,
+    and the API-slot key/hash scheme) and **`@clean-jsdoc-theme/aadesh`** (the
+    `clean-jsdoc` CLI: `extract` / `prompt` / `validate` / `build`, plus an
+    interactive menu). Translatable content spans UI chrome, API
+    descriptions/summaries/example captions/parameter + return descriptions, and
+    prose (a per-locale `README.<locale>.md` home and a `docs.<locale>/` overlay).
+    Opt in with `opts.locales` / `opts.defaultLocale`; a build with no locales stays
+    byte-identical. The TypeDoc bridge supports _extract_ today; the localized
+    _build_ is JSDoc-only for now.
+  - **`clean-jsdoc prompt` writes files.** The LLM translation prompt is now written
+    to Markdown files under `clean-jsdoc-theme-artifacts/locales/prompts/` (chunked,
+    git-ignored, regenerated each run) instead of being dumped to the console — so
+    you can paste or upload each file straight into an LLM.
+  - **Unicode-aware heading anchors.** `slugifyHeading` / `slugifyPath` /
+    `slugifySourcePath` now keep non-ASCII letters (and recompose to NFC), so Hindi,
+    Japanese, and CJK headings get meaningful anchors, a working TOC, and valid
+    `#fragment` links. Latin accent folding (`café → cafe`) is preserved.
+  - **Sidebar TOC fix.** The active TOC entry is scrolled into view on long tables
+    of contents.
+  - **Maintenance.** Package version constants are derived from `package.json` at
+    build time (no more drift), and the package READMEs were refreshed to match the
+    current code.
+
+### Patch Changes
+
+- Updated dependencies
+  - @clean-jsdoc-theme/utils@5.0.0-alpha.4
+  - @clean-jsdoc-theme/bhasha@5.0.0-alpha.4
+
 ## 5.0.0-alpha.3
 
 ### Minor Changes

--- a/packages/setu/package.json
+++ b/packages/setu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clean-jsdoc-theme/setu",
-  "version": "5.0.0-alpha.3",
+  "version": "5.0.0-alpha.4",
   "description": "JSDoc doclet processing and MDX generation",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/typedoc/CHANGELOG.md
+++ b/packages/typedoc/CHANGELOG.md
@@ -1,5 +1,44 @@
 # @clean-jsdoc-theme/typedoc
 
+## 5.0.0-alpha.4
+
+### Minor Changes
+
+- Localization (i18n), prompt-to-file, Unicode anchors, and polish.
+  - **Multi-language documentation.** A new localization pipeline renders one static
+    site per locale (the default unprefixed, others under `/<locale>`) with a header
+    language switcher, `hreflang` alternates, and per-language fonts. Two new
+    packages drive it: **`@clean-jsdoc-theme/bhasha`** (the pure, browser-safe i18n
+    core — chrome catalog, the `t` translator + fallback chain, `LanguageProvider`,
+    and the API-slot key/hash scheme) and **`@clean-jsdoc-theme/aadesh`** (the
+    `clean-jsdoc` CLI: `extract` / `prompt` / `validate` / `build`, plus an
+    interactive menu). Translatable content spans UI chrome, API
+    descriptions/summaries/example captions/parameter + return descriptions, and
+    prose (a per-locale `README.<locale>.md` home and a `docs.<locale>/` overlay).
+    Opt in with `opts.locales` / `opts.defaultLocale`; a build with no locales stays
+    byte-identical. The TypeDoc bridge supports _extract_ today; the localized
+    _build_ is JSDoc-only for now.
+  - **`clean-jsdoc prompt` writes files.** The LLM translation prompt is now written
+    to Markdown files under `clean-jsdoc-theme-artifacts/locales/prompts/` (chunked,
+    git-ignored, regenerated each run) instead of being dumped to the console — so
+    you can paste or upload each file straight into an LLM.
+  - **Unicode-aware heading anchors.** `slugifyHeading` / `slugifyPath` /
+    `slugifySourcePath` now keep non-ASCII letters (and recompose to NFC), so Hindi,
+    Japanese, and CJK headings get meaningful anchors, a working TOC, and valid
+    `#fragment` links. Latin accent folding (`café → cafe`) is preserved.
+  - **Sidebar TOC fix.** The active TOC entry is scrolled into view on long tables
+    of contents.
+  - **Maintenance.** Package version constants are derived from `package.json` at
+    build time (no more drift), and the package READMEs were refreshed to match the
+    current code.
+
+### Patch Changes
+
+- Updated dependencies
+  - @clean-jsdoc-theme/utils@5.0.0-alpha.4
+  - @clean-jsdoc-theme/setu@5.0.0-alpha.4
+  - @clean-jsdoc-theme/dwar@5.0.0-alpha.4
+
 ## 5.0.0-alpha.3
 
 ### Minor Changes

--- a/packages/typedoc/package.json
+++ b/packages/typedoc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clean-jsdoc-theme/typedoc",
-  "version": "5.0.0-alpha.3",
+  "version": "5.0.0-alpha.4",
   "description": "TypeDoc support for clean-jsdoc-theme (renders via setu → dwar)",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -1,5 +1,37 @@
 # @clean-jsdoc-theme/utils
 
+## 5.0.0-alpha.4
+
+### Minor Changes
+
+- Localization (i18n), prompt-to-file, Unicode anchors, and polish.
+  - **Multi-language documentation.** A new localization pipeline renders one static
+    site per locale (the default unprefixed, others under `/<locale>`) with a header
+    language switcher, `hreflang` alternates, and per-language fonts. Two new
+    packages drive it: **`@clean-jsdoc-theme/bhasha`** (the pure, browser-safe i18n
+    core — chrome catalog, the `t` translator + fallback chain, `LanguageProvider`,
+    and the API-slot key/hash scheme) and **`@clean-jsdoc-theme/aadesh`** (the
+    `clean-jsdoc` CLI: `extract` / `prompt` / `validate` / `build`, plus an
+    interactive menu). Translatable content spans UI chrome, API
+    descriptions/summaries/example captions/parameter + return descriptions, and
+    prose (a per-locale `README.<locale>.md` home and a `docs.<locale>/` overlay).
+    Opt in with `opts.locales` / `opts.defaultLocale`; a build with no locales stays
+    byte-identical. The TypeDoc bridge supports _extract_ today; the localized
+    _build_ is JSDoc-only for now.
+  - **`clean-jsdoc prompt` writes files.** The LLM translation prompt is now written
+    to Markdown files under `clean-jsdoc-theme-artifacts/locales/prompts/` (chunked,
+    git-ignored, regenerated each run) instead of being dumped to the console — so
+    you can paste or upload each file straight into an LLM.
+  - **Unicode-aware heading anchors.** `slugifyHeading` / `slugifyPath` /
+    `slugifySourcePath` now keep non-ASCII letters (and recompose to NFC), so Hindi,
+    Japanese, and CJK headings get meaningful anchors, a working TOC, and valid
+    `#fragment` links. Latin accent folding (`café → cafe`) is preserved.
+  - **Sidebar TOC fix.** The active TOC entry is scrolled into view on long tables
+    of contents.
+  - **Maintenance.** Package version constants are derived from `package.json` at
+    build time (no more drift), and the package READMEs were refreshed to match the
+    current code.
+
 ## 5.0.0-alpha.3
 
 ### Minor Changes

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clean-jsdoc-theme/utils",
-  "version": "5.0.0-alpha.3",
+  "version": "5.0.0-alpha.4",
   "description": "Shared types and schemas for clean-jsdoc-theme",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Release prep — v5.0.0-alpha.4

Version bump for the lockstep suite, `5.0.0-alpha.3 → 5.0.0-alpha.4` (changeset **pre** mode, tag `alpha`). All 8 published packages bump together.

### What's in this release (since alpha.3)
- **Localization (i18n) suite** — new `@clean-jsdoc-theme/bhasha` (pure i18n core) + `@clean-jsdoc-theme/aadesh` (`clean-jsdoc` CLI: extract / prompt / validate / build + interactive menu); translatable API slots in setu; language switcher + chrome-via-`t()` in rang; per-locale build mode, chrome seeding, and `hreflang` in dwar; per-locale fonts + `README.<locale>.md` home + `docs.<locale>/` overlay. Opt in via `opts.locales` / `opts.defaultLocale`; no-locale builds stay byte-identical. (TypeDoc: extract works; localized build is JSDoc-only.)
- **`clean-jsdoc prompt` writes files** under `clean-jsdoc-theme-artifacts/locales/prompts/` instead of the console.
- **Unicode-aware heading anchors** — `slugify*` keep non-ASCII letters (+ NFC), so Hindi/Japanese/CJK headings get working anchors, TOC, and `#fragment` links.
- **Sidebar TOC fix** (active item scrolled into view) and **maintenance** (version constants from package.json, refreshed READMEs).

### Mechanics
- New changeset `.changeset/alpha-4-localization.md` (minor, all 8 packages), applied via `pnpm version-packages`.
- Bumped every `package.json` + `CHANGELOG.md` in the `fixed` group, synced `pnpm-lock.yaml` and internal `workspace:*` deps, and recorded the changeset in `.changeset/pre.json` (kept until `pre exit`).

### Verified locally
`pnpm build` ✓ · `pnpm test` (16) ✓ · `pnpm typecheck` (16) ✓ · `pnpm lint` ✓ (0 errors, 1 pre-existing dwar warning).

### To publish (after merge)
```sh
git tag v5.0.0-alpha.4
git push origin v5.0.0-alpha.4   # triggers release.yml → publishes under the `next` dist-tag
```