### PR TITLE
fix: index name clash + render-error diagnostics (#333)

### DIFF
--- a/docs/2026-06-20-issue-333-index-clash-render-diagnostics-design.md
+++ b/docs/2026-06-20-issue-333-index-clash-render-diagnostics-design.md
@@ -1,0 +1,307 @@
+# Issue #333 — Index name clash + render-error diagnostics
+
+**Date:** 2026-06-20
+**Issue:** https://github.com/ankitskvmdam/clean-jsdoc-theme/issues/333
+**Status:** Implemented (2026-06-23) — both fixes landed with tests; see "Implementation notes" below
+
+## Background
+
+Issue #333 is a v4→v5 migration report. Five points were triaged in the issue
+thread; two are concrete engineering work items addressed by this spec:
+
+1. **Index name clash** (confirmed bug): the home page and a documented symbol
+   named `index` resolve to the same output path; the symbol's page silently
+   overwrites the home page.
+2. **Render-error diagnostics** (the reporter's live blocker): the Globals page
+   fails MDX compilation with `global: Could not parse expression with acorn`,
+   and the reporter cannot find *where* the problem is — the build prints only
+   the slug and a terse message, with no location or source context.
+
+The other three points (events-as-section, externals→Globals, file-naming) are
+out of scope here.
+
+Both fixes preserve the existing resilience guarantees: a page that fails to
+compile is still skipped and reported, never thrown; the build never aborts on
+one bad page.
+
+---
+
+## Fix 1 — Index name clash
+
+### Root cause
+
+`packages/dwar/src/html.ts`, `htmlPathFor()`:
+
+```ts
+export function htmlPathFor(slug: string): string {
+  const clean = slug.replace(/^\/+|\/+$/g, '');
+  if (clean === '' || clean === 'index') return 'index.html'; // <-- bug
+  return `${clean}/index.html`;
+}
+```
+
+The `clean === 'index'` branch maps **both** the empty/root slug (the home page,
+slug `''`) and the literal slug `'index'` to `index.html`.
+
+A documented container named `index` (class / module / namespace / interface /
+mixin) gets its slug from `slugifyPath(splitLongnameForSlug(longname))`, which
+yields the string `'index'`. setu emits this as a normal page with a distinct
+slug, so it is *not* caught by the `claimedSlugs` collision set in
+`packages/setu/src/index.ts` (that set compares slug **strings**, and `''` ≠
+`'index'`). Both pages survive into the manifest.
+
+At write time, dwar maps both pages to the path `index.html`. The home page is
+pushed first (`pages.push(home)`), the API pages after, so the `index`-named
+container's page is written **second and clobbers the home page's
+`index.html`**. This is exactly the reporter's symptom; their `@alias` rename is
+a workaround that changes the symbol's longname so its slug is no longer
+`'index'`.
+
+`mdPathFor` derives from `htmlPathFor`, so the companion `.md` files collide the
+same way.
+
+There is an explicit test asserting the current (buggy) behavior:
+`packages/dwar/src/__tests__/html.test.ts:163` —
+`expect(htmlPathFor('index')).toBe('index.html')`. This confirms the collapse was
+intentional design, not an accident; it is the design that backfires.
+
+### Resolution (approved option: own `/index/` directory)
+
+Drop the `clean === 'index'` branch so only the empty/root slug maps to root:
+
+```ts
+export function htmlPathFor(slug: string): string {
+  const clean = slug.replace(/^\/+|\/+$/g, '');
+  if (clean === '') return 'index.html';
+  return `${clean}/index.html`;
+}
+```
+
+Result:
+
+| slug      | output path         | URL       |
+| --------- | ------------------- | --------- |
+| `''`      | `index.html`        | `/`       |
+| `'index'` | `index/index.html`  | `/index/` |
+| `'foo'`   | `foo/index.html`    | `/foo/`   |
+
+- Home keeps the site root.
+- A symbol named `index` lands at `/index/` like any other container — no data
+  loss, no rename, fully deterministic.
+- The slug string `'index'` already flows consistently through nav, the search
+  index, and the link registry; only the final path mapping was collapsing it,
+  so no other layer needs to change.
+- `mdPathFor` follows automatically (it derives from `htmlPathFor`).
+
+### Why not the alternatives
+
+- **Auto-suffix the slug (`index-1`)**: keeps the collapse but produces an
+  uglier, less predictable URL and requires a special case in setu's slug
+  assignment. Rejected.
+- **Home wins, skip the `index` page + warn**: simplest, but *loses* the
+  symbol's documentation page entirely — the same pain the reporter hit.
+  Rejected.
+
+### Files touched
+
+- `packages/dwar/src/html.ts` — remove the `clean === 'index'` branch in
+  `htmlPathFor` (one line). `mdPathFor` needs no change.
+
+### Tests
+
+- `packages/dwar/src/__tests__/html.test.ts`
+  - Update the existing case (line ~163): `htmlPathFor('index')` →
+    `'index/index.html'` (rename the test description accordingly).
+  - Add `mdPathFor('index')` → `'index/index.md'`.
+  - Keep `htmlPathFor('')` → `'index.html'` and `mdPathFor('')` → `'index.md'`.
+- Regression test (in dwar's render/index tests): a manifest containing **both**
+  a home page (slug `''`) and a container page with slug `'index'` emits two
+  **distinct** output paths (`index.html` and `index/index.html`), and the home
+  page's contents are not overwritten.
+
+### Risk / compatibility
+
+- This changes the URL of any site that documents a symbol literally named
+  `index`: previously it (incorrectly) sat at `/` and clobbered home; now it
+  sits at `/index/`. This is a strict correctness improvement — the previous
+  behavior was a broken home page.
+- No other slug is affected (the branch only ever matched the exact string
+  `'index'`). Docs at nested paths like `foo/index` are unaffected (the guard
+  matched only the bare `'index'`, and `deriveDocMeta` already maps a root
+  `index.md` to slug `''`, not `'index'`).
+
+---
+
+## Fix 2 — Render-error diagnostics
+
+### Root cause
+
+`packages/dwar/src/index.ts`, the per-page render `task` catch (~line 586):
+
+```ts
+} catch (err) {
+  return {
+    ok: false,
+    error: { slug: page.slug, message: err instanceof Error ? err.message : String(err) },
+  };
+}
+```
+
+`compileMdxToComponent(page.body, …)` runs MDX's `evaluate`. On a parse failure
+it throws a **`VFileMessage`** (extends `Error`). Verified shape for the
+`acorn` case:
+
+```
+name:    "3:38"
+message: "Could not parse expression with acorn"
+reason:  "Could not parse expression with acorn"
+line:    3
+column:  38
+place:   { line: 3, column: 38, offset: 46 }
+```
+
+The catch keeps only `err.message`, discarding `.line` / `.column` / `.place`.
+The bridge (`packages/clean-jsdoc-theme/src/publish.ts:1846`) then prints just:
+
+```
+  - global: Could not parse expression with acorn
+```
+
+So the location data **exists** but is thrown away — which is exactly why the
+reporter has no way to find the offending content on a large aggregated page
+like Globals.
+
+### Line-number fidelity
+
+`compileMdxToComponent` compiles `escapeStrayBraces(preprocessJsdocInlineTags(page.body))`.
+Both transforms are **line-count preserving**:
+
+- `preprocessJsdocInlineTags` replaces `{@tag …}` with an inline code span
+  **within a line** (no newline added/removed).
+- `escapeStrayBraces` replaces `{`/`}` with `\{`/`\}` **within a line**, and
+  passes fenced/inline code and frontmatter through unchanged.
+
+Therefore `err.line` from the cleaned source maps **1:1** to the authored
+`page.body` line. The column may shift by the number of escapes inserted earlier
+on the same line, so the caret column is **best-effort**; the line is exact.
+This is sufficient to locate the problem and avoids the complexity of a full
+source map (YAGNI).
+
+### Resolution
+
+Surface the location and a code-frame snippet through the existing
+`RenderError` channel.
+
+**`packages/utils/src/site/render.ts`** — extend `RenderError` with optional,
+back-compatible fields:
+
+```ts
+export interface RenderError {
+  slug: string;
+  message: string;
+  /** 1-based source line of the failure, when the error carries a position. */
+  line?: number;
+  /** 1-based source column of the failure (best-effort — see spec). */
+  column?: number;
+  /** A few numbered lines of `page.body` around the failure, with a caret. */
+  snippet?: string;
+}
+```
+
+**`packages/dwar/src/index.ts`** — in the `task` catch, detect a positioned
+error (presence of a numeric `line`) and enrich the `RenderError`:
+
+- Read `line` / `column` off the thrown error (narrow via a small type guard,
+  e.g. `typeof (err as { line?: unknown }).line === 'number'`).
+- Build the snippet from `page.body` with a helper
+  `codeFrame(body: string, line: number, column?: number, context = 2): string`:
+  - Split `body` into lines.
+  - Emit lines `[line-context, line+context]`, each prefixed with a
+    right-aligned 1-based line number and ` | `.
+  - Under the offending line, emit a caret (`^`) row aligned to `column` (when
+    `column` is known), using the same gutter width.
+- Leave `message` as the raw reason (`err.message`); add `line`, `column`,
+  `snippet`.
+- When the error carries no position (non-VFileMessage failures), behavior is
+  unchanged — only `slug` + `message`.
+
+`codeFrame` is a pure local helper in `dwar/src/index.ts` (or a small sibling
+module if it grows); it has no dependencies and is unit-testable in isolation.
+
+**`packages/clean-jsdoc-theme/src/publish.ts`** (~line 1842) — when the optional
+fields are present, print location + indented snippet:
+
+```
+clean-jsdoc-theme: 1 page(s) failed to render and were skipped:
+  - global (line 142:38): Could not parse expression with acorn
+      140 | ## someGlobal
+      141 |
+      142 | Returns a value where {x: y} maps keys.
+          |                       ^
+```
+
+When `line` is absent, fall back to the current `  - <slug>: <message>` form.
+
+**`packages/typedoc/src/write-site.ts`** — the TypeDoc bridge consumes the same
+`RenderResult.errors`. If it prints them with its own formatter, mirror the
+same location + snippet formatting there so both bridges behave identically. (If
+it shares a printer, no change.)
+
+### Files touched
+
+- `packages/utils/src/site/render.ts` — three optional fields on `RenderError`.
+- `packages/dwar/src/index.ts` — enrich the catch; add `codeFrame` helper.
+- `packages/clean-jsdoc-theme/src/publish.ts` — richer skipped-page print.
+- `packages/typedoc/src/write-site.ts` — mirror the print (only if it has its
+  own error printer).
+
+### Tests
+
+- `codeFrame` unit tests: numbered gutter, context window clamped at file
+  start/end, caret alignment with and without a `column`, multi-digit line
+  numbers (gutter width).
+- dwar render test: a page whose `body` contains a deliberately MDX-hostile
+  expression produces a `RenderError` with `line`, `column`, and a `snippet`
+  that includes the offending line; the build still succeeds (page skipped, not
+  thrown).
+- Back-compat: a `RenderError` without a position still serializes/prints in the
+  legacy `slug: message` form.
+
+### Scope guards (YAGNI)
+
+- No change to the skip-don't-throw resilience.
+- No attempt to **auto-fix** the offending content — improving
+  `escapeStrayBraces` robustness is a separate effort.
+- No source map between cleaned and authored text — line-exact + best-effort
+  caret column is enough to locate the problem.
+
+---
+
+## Implementation notes (2026-06-23)
+
+Both fixes landed as specified, with one intentional refinement to Fix 2's
+print path:
+
+- **Shared printer instead of duplicated formatting.** Rather than re-implementing
+  the location + snippet formatting in each bridge, the print logic lives once in
+  `packages/utils/src/site/render.ts` as `formatRenderError(error, indent?)`. Both
+  bridges call it (`publish.ts` adds it to its dynamic-import allowlist; `write-site.ts`
+  imports it directly), so they print identically by construction — the spec's
+  "mirror the same formatting" goal, but without the drift risk of two copies.
+- `codeFrame` is exported from `dwar/src/index.ts` (so it's unit-testable) and used
+  in the per-page render catch, guarded by `isPositionedError` (numeric `line`).
+- The MDX-hostile construct exercised by the dwar render test is an angle-bracket
+  autolink (`<https://example.com>`): it survives the brace-escaping pre-pass and
+  fails `acorn` with a positioned `VFileMessage`, matching the reporter's symptom.
+
+Verified: `utils` + `dwar` test suites pass (incl. the new `codeFrame`, index-clash,
+diagnostics, and `formatRenderError` back-compat cases); `utils`/`dwar`/`clean-jsdoc-theme`/`typedoc`
+typecheck and lint clean.
+
+## Out of scope
+
+- Events as a separate sidebar section (issue point 1).
+- Externals folded into the Globals "Other" section / v4 parity (issue point 2).
+- The v5 file-naming change (issue point 3) — by design, not a bug.
+- Improving `escapeStrayBraces` / `preprocessJsdocInlineTags` to *prevent* the
+  acorn failure (separate effort; Fix 2 only makes the failure locatable).

--- a/examples/basic/src/globals.js
+++ b/examples/basic/src/globals.js
@@ -1,0 +1,34 @@
+/**
+ * Resolve the effective runtime configuration for the app.
+ *
+ * Defaults are `host: "localhost"` and `port: 3000`. Pass an `overrides` object
+ * to shallow-merge on top — for example `{ port: 8080 }` changes just the port
+ * and leaves the rest at their defaults.
+ *
+ * @function getConfig
+ * @global
+ * @param {Object} [overrides] - Partial config to merge over the defaults.
+ * @param {string} [overrides.host] - Hostname to bind to.
+ * @param {number} [overrides.port] - Port to listen on.
+ * @returns {Object} The resolved configuration.
+ *
+ * @example
+ * const cfg = getConfig({ port: 8080 });
+ * // => { host: 'localhost', port: 8080 }
+ */
+function getConfig(overrides) {
+  return Object.assign({ host: 'localhost', port: 3000 }, overrides);
+}
+
+/**
+ * Format a byte count as a human-readable size (e.g. `1.5 kB`).
+ *
+ * @function humanSize
+ * @global
+ * @param {number} bytes - The byte count.
+ * @returns {string} The formatted size.
+ */
+function humanSize(bytes) {
+  if (bytes < 1000) return `${bytes} B`;
+  return `${(bytes / 1000).toFixed(1)} kB`;
+}

--- a/packages/clean-jsdoc-theme/src/publish.ts
+++ b/packages/clean-jsdoc-theme/src/publish.ts
@@ -148,6 +148,7 @@ const loadUtils = (): Promise<typeof import('@clean-jsdoc-theme/utils')> =>
     'createGoogleFontResolver',
     'formatDiagnostics',
     'formatBuildReport',
+    'formatRenderError',
     'normalizeBasePath',
     'withBase',
     'toExtractManifest',
@@ -1564,6 +1565,7 @@ export async function publish(data: unknown, opts: JSDocOpts, tutorials?: unknow
       createGoogleFontResolver,
       formatDiagnostics,
       formatBuildReport,
+      formatRenderError,
       normalizeBasePath,
       withBase,
       toExtractManifest,
@@ -1844,7 +1846,7 @@ export async function publish(data: unknown, opts: JSDocOpts, tutorials?: unknow
       `clean-jsdoc-theme: ${result.errors.length} page(s) failed to render and were skipped:`
     );
     for (const e of result.errors) {
-      console.warn(`  - ${e.slug}: ${e.message}`);
+      console.warn(formatRenderError(e));
     }
   }
 

--- a/packages/dwar/src/__tests__/html.test.ts
+++ b/packages/dwar/src/__tests__/html.test.ts
@@ -160,8 +160,8 @@ describe('htmlPathFor', () => {
   it('returns index.html for an empty slug', () => {
     expect(htmlPathFor('')).toBe('index.html');
   });
-  it('returns index.html for the literal "index" slug', () => {
-    expect(htmlPathFor('index')).toBe('index.html');
+  it('gives a symbol named "index" its own directory (not the site root)', () => {
+    expect(htmlPathFor('index')).toBe('index/index.html');
   });
   it('treats slug as a directory', () => {
     expect(htmlPathFor('guide/intro')).toBe('guide/intro/index.html');
@@ -176,6 +176,9 @@ describe('mdPathFor', () => {
     expect(mdPathFor('')).toBe('index.md');
     expect(mdPathFor('guide/intro')).toBe('guide/intro/index.md');
     expect(mdPathFor('/foo/bar/')).toBe('foo/bar/index.md');
+  });
+  it('gives a symbol named "index" its own .md (not the home .md)', () => {
+    expect(mdPathFor('index')).toBe('index/index.md');
   });
 });
 

--- a/packages/dwar/src/__tests__/render.test.ts
+++ b/packages/dwar/src/__tests__/render.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
-import { render } from '../index';
+import { render, codeFrame } from '../index';
 import { makeManifest, minimalTheme } from './fixtures';
-import type { OutputFile } from '@clean-jsdoc-theme/utils';
+import type { OutputFile, SiteManifest } from '@clean-jsdoc-theme/utils';
 
 function asString(file: OutputFile): string {
   return typeof file.contents === 'string'
@@ -639,5 +639,121 @@ describe('render() — header controls visibility (mobile + desktop)', () => {
     expect(wrapperClassFor(home, 'language-switcher')).toBeNull();
     // And search remains visible alongside it on every breakpoint.
     expect(wrapperClassFor(home, 'cmdk')).not.toContain('hidden');
+  });
+});
+
+describe('codeFrame', () => {
+  const body = ['line one', 'line two', 'line three', 'line four', 'line five'].join('\n');
+
+  it('emits a numbered gutter around the target line', () => {
+    const frame = codeFrame(body, 3);
+    expect(frame).toContain('1 | line one');
+    expect(frame).toContain('3 | line three');
+    expect(frame).toContain('5 | line five');
+  });
+
+  it('clamps the context window at the start of the file', () => {
+    const frame = codeFrame(body, 1).split('\n');
+    // No line 0; the window starts at line 1 and extends `context` lines down.
+    expect(frame[0]).toBe('1 | line one');
+    expect(frame.some((l) => l.startsWith('3 |'))).toBe(true);
+    expect(frame.some((l) => l.startsWith('4 |'))).toBe(false);
+  });
+
+  it('clamps the context window at the end of the file', () => {
+    const frame = codeFrame(body, 5).split('\n');
+    expect(frame.some((l) => l.startsWith('2 |'))).toBe(false);
+    expect(frame[frame.length - 1]).toBe('5 | line five');
+  });
+
+  it('aligns a caret under the column when given', () => {
+    const frame = codeFrame(body, 3, 6).split('\n');
+    const targetIdx = frame.findIndex((l) => l.startsWith('3 |'));
+    const caretRow = frame[targetIdx + 1];
+    // Gutter width is 1 here ("5"), so the caret row is `" | " + (col-1) spaces + ^`.
+    expect(caretRow).toBe('  | ' + ' '.repeat(5) + '^');
+  });
+
+  it('omits the caret row when no column is given', () => {
+    const frame = codeFrame(body, 3).split('\n');
+    expect(frame.every((l) => !l.includes('^'))).toBe(true);
+  });
+
+  it('widens the gutter for multi-digit line numbers', () => {
+    const long = Array.from({ length: 12 }, (_, i) => `row ${i + 1}`).join('\n');
+    const frame = codeFrame(long, 10).split('\n');
+    // End line is 12 (two digits), so single-digit numbers are right-padded.
+    expect(frame).toContain(' 8 | row 8');
+    expect(frame).toContain('12 | row 12');
+  });
+});
+
+describe('render() — issue #333: index name clash', () => {
+  function manifestWithIndexSymbol(): SiteManifest {
+    const m = makeManifest();
+    m.pages.push({
+      slug: 'index',
+      frontmatter: { title: 'index', kind: 'class', description: 'A class named index.' },
+      body: `# index\n\nA documented symbol literally named index.\n`,
+      headings: [],
+    });
+    m.nav.push({ label: 'index', slug: 'index' });
+    return m;
+  }
+
+  it('emits distinct paths for the home page and an "index"-named symbol', async () => {
+    const result = await render(manifestWithIndexSymbol(), { theme: minimalTheme });
+    const paths = result.files.map((f) => f.path);
+    expect(paths).toContain('index.html'); // home
+    expect(paths).toContain('index/index.html'); // the symbol
+    // The companion .md files follow the same split.
+    expect(paths).toContain('index.md');
+    expect(paths).toContain('index/index.md');
+  });
+
+  it('does not let the "index" symbol overwrite the home page', async () => {
+    const result = await render(manifestWithIndexSymbol(), { theme: minimalTheme });
+    const home = asString(result.files.find((f) => f.path === 'index.html')!);
+    const symbol = asString(result.files.find((f) => f.path === 'index/index.html')!);
+    expect(home).toContain('home');
+    expect(home).not.toContain('A documented symbol literally named index');
+    expect(symbol).toContain('A documented symbol literally named index');
+  });
+});
+
+describe('render() — issue #333: render-error diagnostics', () => {
+  function manifestWithBadPage(): SiteManifest {
+    const m = makeManifest();
+    // An angle-bracket autolink is MDX-hostile: `<https:` reads as a JSX tag and
+    // acorn rejects it. It survives the brace-escaping pre-pass (no braces), so
+    // the page fails to compile with a positioned VFileMessage.
+    m.pages.push({
+      slug: 'bad',
+      frontmatter: { title: 'Bad', kind: 'guide', description: 'A page that will not compile.' },
+      body: `# Bad page\n\nIntro line.\n\nSee <https://example.com> for more.\n`,
+      headings: [],
+    });
+    m.nav.push({ label: 'Bad', slug: 'bad' });
+    return m;
+  }
+
+  it('skips the bad page (not thrown) and still renders the good pages', async () => {
+    const result = await render(manifestWithBadPage(), { theme: minimalTheme });
+    const paths = result.files.map((f) => f.path);
+    expect(paths).toContain('index.html'); // home still rendered
+    expect(paths).not.toContain('bad/index.html'); // bad page skipped
+    expect(result.errors).toBeDefined();
+    expect(result.errors!.some((e) => e.slug === 'bad')).toBe(true);
+  });
+
+  it('enriches the RenderError with line, column, and a code-frame snippet', async () => {
+    const result = await render(manifestWithBadPage(), { theme: minimalTheme });
+    const err = result.errors!.find((e) => e.slug === 'bad')!;
+    expect(typeof err.line).toBe('number');
+    expect(err.snippet).toBeTruthy();
+    // The snippet locates the offending source line.
+    expect(err.snippet).toContain('See <https://example.com> for more.');
+    // The reported line points at that line in the body (1-based).
+    expect(err.snippet).toContain(`${err.line} |`);
   });
 });

--- a/packages/dwar/src/__tests__/render.test.ts
+++ b/packages/dwar/src/__tests__/render.test.ts
@@ -756,4 +756,39 @@ describe('render() — issue #333: render-error diagnostics', () => {
     // The reported line points at that line in the body (1-based).
     expect(err.snippet).toContain(`${err.line} |`);
   });
+
+  // The exact failure from issue #333: an aggregated Globals page where one
+  // symbol's doc comment has an unbalanced inline-code backtick straddling a
+  // blank line, with a `{...}` between the ticks. The brace-escaping pre-pass
+  // treats the whole run as code (so the brace survives), but a Markdown code
+  // span can't cross a paragraph break — so MDX reads `{...}` as a flow
+  // expression and acorn rejects it. This is the v4→v5 trap: v4 rendered the
+  // description as raw HTML and never choked.
+  it('reproduces "Could not parse expression with acorn" and locates it', async () => {
+    const m = makeManifest();
+    m.pages.push({
+      slug: 'global',
+      frontmatter: { title: 'Globals', kind: 'guide', description: 'Aggregated globals.' },
+      body: [
+        '# Globals',
+        '',
+        '## getConfig',
+        '',
+        'Pass `{ port: 8080 } to override just the port',
+        '',
+        'and keep the `rest`.',
+      ].join('\n'),
+      headings: [],
+    });
+    const result = await render(m, { theme: minimalTheme });
+    const err = result.errors!.find((e) => e.slug === 'global')!;
+    expect(err.message).toBe('Could not parse expression with acorn');
+    expect(typeof err.line).toBe('number');
+    // The snippet shows the offending line so the symbol is locatable on a big
+    // aggregated page — the whole point of the issue #333 diagnostics fix.
+    expect(err.snippet).toContain('Pass `{ port: 8080 } to override just the port');
+    // And the page is skipped, never thrown — the Globals page just goes missing,
+    // which is exactly why the reporter saw "no globals".
+    expect(result.files.map((f) => f.path)).not.toContain('global/index.html');
+  });
 });

--- a/packages/dwar/src/html.ts
+++ b/packages/dwar/src/html.ts
@@ -380,10 +380,14 @@ export function extractSearchText(mdxBody: string, max = 20000): string {
   return text.length > max ? text.slice(0, max) : text;
 }
 
-/** Slug → output HTML path. Empty/root slug becomes `index.html`. */
+/**
+ * Slug → output HTML path. Only the empty/root slug (the home page) maps to
+ * `index.html`; a symbol literally named `index` keeps its own slug and lands at
+ * `index/index.html` (`/index/`), so it can't clobber the home page (issue #333).
+ */
 export function htmlPathFor(slug: string): string {
   const clean = slug.replace(/^\/+|\/+$/g, '');
-  if (clean === '' || clean === 'index') return 'index.html';
+  if (clean === '') return 'index.html';
   return `${clean}/index.html`;
 }
 

--- a/packages/dwar/src/index.ts
+++ b/packages/dwar/src/index.ts
@@ -71,6 +71,45 @@ function mergeMdxComponents(override?: Record<string, unknown>): MdxComponentMap
   return { ...defaultMdxComponents, ...(override as MdxComponentMap) };
 }
 
+/** A positioned thrown error (e.g. MDX's `VFileMessage`) carries a numeric line. */
+interface PositionedError {
+  line: number;
+  column?: number;
+}
+
+/**
+ * Narrow a thrown value to one carrying a numeric `line` (MDX compile failures
+ * throw a `VFileMessage`, whose `.line`/`.column` point at the source position).
+ * Other failures have no position and fall through to a bare slug + message.
+ */
+function isPositionedError(err: unknown): err is PositionedError {
+  return typeof (err as { line?: unknown }).line === 'number';
+}
+
+/**
+ * A small numbered code-frame around `line` in `body`, for locating a render
+ * failure on a large aggregated page (e.g. Globals). Emits the `context` lines
+ * on either side of `line`, each with a right-aligned 1-based gutter and ` | `,
+ * and — when `column` is known — a caret row under the offending line aligned to
+ * it. The line is exact (the MDX pre-passes preserve line counts); the caret
+ * column is best-effort (earlier same-line escapes may shift it). See issue #333.
+ */
+export function codeFrame(body: string, line: number, column?: number, context = 2): string {
+  const lines = body.split('\n');
+  const start = Math.max(1, line - context);
+  const end = Math.min(lines.length, line + context);
+  const gutterWidth = String(end).length;
+  const out: string[] = [];
+  for (let n = start; n <= end; n++) {
+    out.push(`${String(n).padStart(gutterWidth)} | ${lines[n - 1] ?? ''}`);
+    if (n === line && typeof column === 'number' && column >= 1) {
+      // Caret aligned under `column`, beneath an empty gutter of the same width.
+      out.push(`${' '.repeat(gutterWidth)} | ${' '.repeat(column - 1)}^`);
+    }
+  }
+  return out.join('\n');
+}
+
 /**
  * Bounded-concurrency `map`: runs `fn` over `items` with at most `limit` tasks
  * in flight, and returns results in the SAME order as `items` (result[i] for
@@ -584,10 +623,24 @@ export async function render(manifest: SiteManifest, opts: RenderOptions): Promi
         members: hidden ? undefined : memberSearchEntries(page),
       };
     } catch (err) {
-      return {
-        ok: false,
-        error: { slug: page.slug, message: err instanceof Error ? err.message : String(err) },
-      };
+      const message = err instanceof Error ? err.message : String(err);
+      // A positioned error (MDX's VFileMessage) carries the source location —
+      // surface it plus a code-frame so a failure on a big aggregated page
+      // (e.g. Globals) is locatable. Non-positioned errors keep slug + message.
+      if (isPositionedError(err) && page.body) {
+        const { line, column } = err;
+        return {
+          ok: false,
+          error: {
+            slug: page.slug,
+            message,
+            line,
+            column,
+            snippet: codeFrame(page.body, line, column),
+          },
+        };
+      }
+      return { ok: false, error: { slug: page.slug, message } };
     }
   };
 

--- a/packages/typedoc/src/write-site.ts
+++ b/packages/typedoc/src/write-site.ts
@@ -35,6 +35,7 @@ import {
   createGoogleFontResolver,
   formatBuildReport,
   formatDiagnostics,
+  formatRenderError,
   toExtractManifest,
   validateThemeOpts,
 } from '@clean-jsdoc-theme/utils';
@@ -699,7 +700,7 @@ export async function writeSite(
     logger.warn(
       `[clean-jsdoc-theme] ${result.errors.length} page(s) failed to render and were skipped:`
     );
-    for (const e of result.errors) logger.warn(`  - ${e.slug}: ${e.message}`);
+    for (const e of result.errors) logger.warn(formatRenderError(e));
   }
 
   // Pagefind is optional; a missing/failing Pagefind must not break the build.

--- a/packages/utils/src/__tests__/render.test.ts
+++ b/packages/utils/src/__tests__/render.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest';
+import { formatRenderError } from '../site/render';
+
+describe('formatRenderError', () => {
+  it('prints the legacy `slug: message` form for an unpositioned error', () => {
+    const out = formatRenderError({ slug: 'global', message: 'boom' });
+    expect(out).toBe('  - global: boom');
+  });
+
+  it('includes the location when line (and column) are present', () => {
+    const out = formatRenderError({
+      slug: 'global',
+      message: 'Could not parse expression with acorn',
+      line: 142,
+      column: 38,
+    });
+    expect(out).toBe('  - global (line 142:38): Could not parse expression with acorn');
+  });
+
+  it('omits the column from the location when only the line is known', () => {
+    const out = formatRenderError({ slug: 'global', message: 'boom', line: 7 });
+    expect(out).toBe('  - global (line 7): boom');
+  });
+
+  it('appends the snippet, indented under the header', () => {
+    const out = formatRenderError({
+      slug: 'global',
+      message: 'boom',
+      line: 3,
+      column: 2,
+      snippet: '2 | a\n3 | b\n  |  ^',
+    });
+    expect(out).toBe(
+      ['  - global (line 3:2): boom', '      2 | a', '      3 | b', '        |  ^'].join('\n')
+    );
+  });
+
+  it('honors a custom indent', () => {
+    const out = formatRenderError({ slug: 'x', message: 'm' }, '    ');
+    expect(out).toBe('    - x: m');
+  });
+});

--- a/packages/utils/src/site/render.ts
+++ b/packages/utils/src/site/render.ts
@@ -18,6 +18,32 @@ export interface RenderError {
   slug: string;
   /** The error message (e.g. an MDX compile failure). */
   message: string;
+  /** 1-based source line of the failure, when the error carries a position. */
+  line?: number;
+  /** 1-based source column of the failure (best-effort — see issue #333 spec). */
+  column?: number;
+  /** A few numbered lines of `page.body` around the failure, with a caret. */
+  snippet?: string;
+}
+
+/**
+ * Format one skipped-page {@link RenderError} for a build log, so both bridges
+ * (JSDoc + TypeDoc) print render failures identically. A positioned error shows
+ * `slug (line L:C): message` followed by its indented code-frame snippet; an
+ * unpositioned one falls back to the legacy `slug: message` single line.
+ */
+export function formatRenderError(error: RenderError, indent = '  '): string {
+  const hasLine = typeof error.line === 'number';
+  const loc = hasLine
+    ? ` (line ${error.line}${typeof error.column === 'number' ? `:${error.column}` : ''})`
+    : '';
+  const header = `${indent}- ${error.slug}${loc}: ${error.message}`;
+  if (!error.snippet) return header;
+  const snippet = error.snippet
+    .split('\n')
+    .map((l) => `${indent}    ${l}`)
+    .join('\n');
+  return `${header}\n${snippet}`;
 }
 
 /** Aggregated result returned by `dwar.render`. Pure — no I/O is performed here. */


### PR DESCRIPTION
Addresses the two concrete engineering work items triaged from the #333 v4→v5 migration report. Full design: `docs/2026-06-20-issue-333-index-clash-render-diagnostics-design.md`.

## Fix 1 — Index name clash

A documented symbol literally named `index` (class / module / namespace / …) got the slug `'index'` and, at write time, mapped to the same `index.html` path as the home page (slug `''`) — silently **overwriting** the home page. This was the reporter's symptom; their `@alias` rename was a workaround.

`htmlPathFor` now maps only the empty/root slug to `index.html`; an `index`-named symbol lands at `index/index.html` (`/index/`), like any other container. `mdPathFor` follows automatically.

| slug | output path | URL |
| --- | --- | --- |
| `''` | `index.html` | `/` |
| `'index'` | `index/index.html` | `/index/` |

## Fix 2 — Render-error diagnostics

MDX compile failures (e.g. the Globals page `Could not parse expression with acorn`) only printed `  - <slug>: <message>` — the thrown `VFileMessage` carries `.line`/`.column`/`.place`, but the catch discarded them, so the reporter couldn't find *where* the problem was on a large aggregated page.

The per-page render catch now detects a positioned error and enriches `RenderError` with `line`, `column`, and a numbered **code-frame** `snippet`. A shared `formatRenderError` in `utils` prints them, so both bridges (JSDoc + TypeDoc) report identically:

```
clean-jsdoc-theme: 1 page(s) failed to render and were skipped:
  - global (line 142:38): Could not parse expression with acorn
      140 | ## someGlobal
      141 |
      142 | Returns a value where {x: y} maps keys.
          |                       ^
```

Resilience is unchanged — a bad page is still skipped + reported, never thrown.

## Notes

- One refinement vs. the design: the location + snippet formatting lives **once** in `utils` (`formatRenderError`) rather than being duplicated per bridge, so they can't drift.
- `line` is exact (the MDX pre-passes preserve line counts); the caret column is best-effort (earlier same-line escapes may shift it) — sufficient to locate, no source map needed.

## Tests / verification

- New: `codeFrame` unit tests (gutter, clamping, caret, multi-digit), index-clash regression (distinct paths, home not overwritten), positioned render-error (line + snippet, page skipped not thrown), `formatRenderError` back-compat.
- `utils` (116) + `dwar` (104) suites pass; `utils`/`dwar`/`clean-jsdoc-theme`/`typedoc` typecheck + lint clean.

Fixes #333