### PR TITLE
feat(typedoc): support the `docs` prose directory in the plugin (#334)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -622,9 +622,14 @@ typedoc/src/
 │                           #   salty.taffy → setu generateSite → dwar render →
 │                           #   write files → Pagefind. Threads validated siteName/
 │                           #   fonts + normalized sectionOrder/menu/clubSidebarItems/
-│                           #   copyPage/pageNav/aiPrompt through. Prints the utils
+│                           #   copyPage/pageNav/aiPrompt through, and walks the
+│                           #   `docs` dir (docs.ts) → docs + docGroups/
+│                           #   defaultDocGroup + inlineSvgs. Prints the utils
 │                           #   formatBuildReport (node:zlib gzip sizer — allowed here,
 │                           #   it's the bridge, not utils). Holds defaultTheme.
+├── docs.ts                 # prose-docs front-end (copied from the JSDoc bridge):
+│                           #   collectDocs (walk dir → DocInput[]) + resolveDocImages
+│                           #   (local images → content-hashed _assets/ + inline SVGs).
 ├── reflection-to-doclets.ts# THE adapter: ProjectReflection → flat TDoclet[].
 │                           #   Class/Interface/Function/Method/Property/Variable/
 │                           #   Accessor/Enum(+isEnum)/EnumMember/TypeAlias(typedef)/
@@ -638,8 +643,9 @@ typedoc/src/
 │                           #   → params/returns/throws/examples/deprecated/see/category.
 ├── types.ts                # TypeDoc Type → { names: [type.toString()] } (v1).
 ├── options.ts              # the cleanJsdocTheme ParameterType.Object declaration +
-│                           #   typed reader (siteName/fonts/sectionOrder/menu/
-│                           #   clubSidebarItems/copyPage/pageNav/aiPrompt/strict).
+│                           #   typed reader (siteName/fonts/sectionOrder/docs/
+│                           #   docGroups/defaultDocGroup/menu/clubSidebarItems/
+│                           #   copyPage/pageNav/aiPrompt/strict).
 └── write-output-files.ts   # mkdir -p + writeFile loop (copied from the JSDoc bridge).
 ```
 

--- a/examples/typedoc-basic/docs/guides/getting-started.md
+++ b/examples/typedoc-basic/docs/guides/getting-started.md
@@ -1,0 +1,22 @@
+---
+title: Getting Started
+group: Guides
+order: 1
+---
+
+# Getting Started
+
+This guide is prose authored in `docs/guides/getting-started.md`. Its directory
+(`guides/`) becomes the **Guides** sidebar group, and its URL is the clean,
+unprefixed slug `/guides/getting-started`.
+
+## Install
+
+```sh
+npm install typedoc-basic
+```
+
+## Next steps
+
+Frontmatter (`title`, `group`, `order`, `slug`, `hidden`) overrides the
+directory-derived defaults per file — exactly like the JSDoc bridge's `docs`.

--- a/examples/typedoc-basic/docs/index.md
+++ b/examples/typedoc-basic/docs/index.md
@@ -1,0 +1,11 @@
+---
+title: Home
+---
+
+# typedoc-basic
+
+This home page comes from `docs/index.md` — a prose page authored in the
+`cleanJsdocTheme.docs` directory, not from a doc comment. It overrides the
+project README as the site home.
+
+Use the sidebar to explore the API, or read the guides below.

--- a/examples/typedoc-basic/typedoc.json
+++ b/examples/typedoc-basic/typedoc.json
@@ -7,6 +7,8 @@
   "outputs": [{ "name": "clean-jsdoc-theme", "path": "dist" }],
   "cleanJsdocTheme": {
     "siteName": "typedoc-basic",
+    "docs": "docs",
+    "docGroups": ["Guides"],
     "sectionOrder": [
       "Core",
       "Shapes",
@@ -16,7 +18,8 @@
       "Interfaces",
       "Enums",
       "Typedefs",
-      "Globals"
+      "Globals",
+      "Guides"
     ],
     "clubSidebarItems": true,
     "copyPage": true

--- a/packages/typedoc/src/__tests__/docs.test.ts
+++ b/packages/typedoc/src/__tests__/docs.test.ts
@@ -1,0 +1,90 @@
+import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { collectDocs, resolveDocImages } from '../docs';
+
+/** A 1x1 transparent PNG (bytes), enough to exercise the image asset pipeline. */
+const PNG_1X1 = Buffer.from(
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==',
+  'base64'
+);
+
+const SVG = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 10"><rect width="10" height="10"/></svg>';
+
+let dir: string;
+const noop = (): void => {};
+
+beforeAll(async () => {
+  dir = await mkdtemp(join(tmpdir(), 'cjt-typedoc-docs-'));
+  await mkdir(join(dir, 'guides'), { recursive: true });
+  await writeFile(join(dir, 'index.md'), '# Home\n\nWelcome.\n', 'utf8');
+  await writeFile(
+    join(dir, 'guides', 'getting-started.md'),
+    '---\ntitle: Getting Started\ngroup: Guides\n---\n\n# Start\n\n![diagram](./diagram.png)\n![logo](./logo.svg)\n',
+    'utf8'
+  );
+  await writeFile(join(dir, 'guides', 'diagram.png'), PNG_1X1);
+  await writeFile(join(dir, 'guides', 'logo.svg'), SVG, 'utf8');
+  // Noise that must be ignored.
+  await writeFile(join(dir, 'notes.txt'), 'ignored', 'utf8');
+  await mkdir(join(dir, '.hidden'), { recursive: true });
+  await writeFile(join(dir, '.hidden', 'secret.md'), '# secret', 'utf8');
+});
+
+afterAll(async () => {
+  await rm(dir, { recursive: true, force: true });
+});
+
+describe('collectDocs', () => {
+  it('walks the tree into DocInputs with POSIX, extension-stripped slugs', async () => {
+    const docs = await collectDocs(dir, noop);
+    const paths = docs.map((d) => d.path);
+    expect(paths).toEqual(['guides/getting-started', 'index']);
+    expect(docs.every((d) => d.type === 'markdown')).toBe(true);
+  });
+
+  it('ignores non-doc files and dot-directories', async () => {
+    const docs = await collectDocs(dir, noop);
+    expect(docs.find((d) => d.path.includes('notes'))).toBeUndefined();
+    expect(docs.find((d) => d.path.includes('secret'))).toBeUndefined();
+  });
+
+  it('returns [] for a missing directory (never throws)', async () => {
+    expect(await collectDocs(join(dir, 'nope'), noop)).toEqual([]);
+    expect(await collectDocs('', noop)).toEqual([]);
+  });
+});
+
+describe('resolveDocImages', () => {
+  it('copies local images to content-hashed _assets and rewrites the src', async () => {
+    const docs = await collectDocs(dir, noop);
+    const resolved = await resolveDocImages(docs, dir, noop);
+    const guide = resolved.docs.find((d) => d.path === 'guides/getting-started')!;
+    // The PNG src is rewritten to a root-relative, hashed _assets path.
+    expect(guide.content).toMatch(/!\[diagram\]\(\/_assets\/diagram\.[0-9a-f]{8}\.png\)/);
+    // Both assets are emitted for writing.
+    expect(resolved.files.map((f) => f.path).some((p) => /_assets\/diagram\.[0-9a-f]{8}\.png/.test(p))).toBe(true);
+    expect(resolved.files.map((f) => f.path).some((p) => /_assets\/logo\.[0-9a-f]{8}\.svg/.test(p))).toBe(true);
+  });
+
+  it('collects SVG markup for inlining, keyed by the rewritten src', async () => {
+    const docs = await collectDocs(dir, noop);
+    const resolved = await resolveDocImages(docs, dir, noop);
+    const keys = Object.keys(resolved.inlineSvgs);
+    expect(keys.length).toBe(1);
+    expect(keys[0]).toMatch(/^\/_assets\/logo\.[0-9a-f]{8}\.svg$/);
+    expect(resolved.inlineSvgs[keys[0]]).toContain('<svg');
+    // A responsive sizing style is injected onto the root <svg>.
+    expect(resolved.inlineSvgs[keys[0]]).toContain('max-width:100%');
+  });
+
+  it('leaves remote/data/anchor srcs untouched', async () => {
+    const docs = [
+      { path: 'x', type: 'markdown' as const, content: '![a](https://e.com/i.png) ![b](#frag) ![c](data:image/png;base64,AA)' },
+    ];
+    const resolved = await resolveDocImages(docs, dir, noop);
+    expect(resolved.docs[0].content).toBe(docs[0].content);
+    expect(resolved.files).toEqual([]);
+  });
+});

--- a/packages/typedoc/src/docs.ts
+++ b/packages/typedoc/src/docs.ts
@@ -1,0 +1,197 @@
+/**
+ * Prose-docs collection for the TypeDoc bridge — the `cleanJsdocTheme.docs`
+ * directory front-end.
+ *
+ * This is the TypeDoc twin of the JSDoc bridge's `collectDocs` / `resolveDocImages`
+ * (in `clean-jsdoc-theme/src/publish.ts`). Per the repo convention, the two
+ * bridges are independent leaf packages: pure helpers are COPIED, never
+ * cross-imported. The only behavioural difference is that warnings go through a
+ * `warn` callback (TypeDoc's `logger.warn`) rather than `console.warn`.
+ *
+ * The bridge is the I/O layer here — it walks the docs tree and routes referenced
+ * images through `_assets/` — so setu/dwar only ever see in-memory `DocInput`s and
+ * already-rewritten `/_assets/…` srcs, and `dwar.render()` stays pure.
+ */
+import { createHash } from 'node:crypto';
+import { readdir, readFile } from 'node:fs/promises';
+import { basename, dirname, extname, join as joinPath, resolve as resolvePath } from 'node:path';
+import type { DocInput } from '@clean-jsdoc-theme/setu';
+import type { OutputFile } from '@clean-jsdoc-theme/dwar';
+
+/** Sink for non-fatal warnings (TypeDoc's `logger.warn`). */
+type Warn = (message: string) => void;
+
+/** A value that's already a servable URL/URI needs no copying. */
+function isServableUrl(value: string): boolean {
+  return /^(https?:)?\/\//i.test(value) || /^data:/i.test(value);
+}
+
+/** Short content hash for cache-busting an asset's served name. */
+function contentHash(bytes: Uint8Array): string {
+  return createHash('sha256').update(bytes).digest('hex').slice(0, 8);
+}
+
+/** Doc-file extensions → `DocInput.type`. Markdown is the priority; html maps to 'html'. */
+const DOC_EXTENSIONS = new Map<string, DocInput['type']>([
+  ['.md', 'markdown'],
+  ['.markdown', 'markdown'],
+  ['.html', 'html'],
+  ['.htm', 'html'],
+]);
+
+/** Directory names skipped while walking a docs tree (build/vcs noise). */
+const DOC_DIR_SKIP = new Set(['node_modules', '.git', '.svn', '.hg']);
+
+/**
+ * Recursively walk a docs directory and read each Markdown/HTML file into a
+ * {@link DocInput} for setu's docs front-end. Mirrors the JSDoc bridge's
+ * `collectDocs`:
+ *
+ * - `path` is the file path relative to `dir`, POSIX-normalized (forward slashes)
+ *   with the extension stripped (`<dir>/guides/advanced.md` → `'guides/advanced'`,
+ *   `<dir>/index.md` → `'index'`).
+ * - `content` is the raw UTF-8 text (frontmatter stays embedded — setu parses it).
+ * - `type` is `'markdown'` for `.md`/`.markdown`, `'html'` for `.html`/`.htm`.
+ *
+ * Resilient by design: a missing/unreadable directory yields `[]` (never throws);
+ * dotfiles/dot-dirs and `node_modules`-like noise are skipped; a single
+ * unreadable file is warned about and skipped. Results are sorted by `path` so
+ * the output is stable build-to-build.
+ */
+export async function collectDocs(dir: string, warn: Warn): Promise<DocInput[]> {
+  if (typeof dir !== 'string' || dir.trim().length === 0) return [];
+  const root = resolvePath(dir);
+  const docs: DocInput[] = [];
+
+  const walk = async (absDir: string, relPrefix: string): Promise<void> => {
+    let entries: import('node:fs').Dirent[];
+    try {
+      entries = await readdir(absDir, { withFileTypes: true });
+    } catch {
+      // Missing/unreadable directory — skip leniently (root miss → []).
+      return;
+    }
+
+    for (const entry of entries) {
+      const name = entry.name;
+      // Skip dotfiles/dot-dirs and known build/vcs noise.
+      if (name.startsWith('.')) continue;
+      if (entry.isDirectory()) {
+        if (DOC_DIR_SKIP.has(name)) continue;
+        await walk(joinPath(absDir, name), relPrefix ? `${relPrefix}/${name}` : name);
+        continue;
+      }
+      if (!entry.isFile()) continue;
+
+      const ext = extname(name).toLowerCase();
+      const type = DOC_EXTENSIONS.get(ext);
+      if (!type) continue;
+
+      const abs = joinPath(absDir, name);
+      const stem = name.slice(0, name.length - ext.length);
+      const relPath = relPrefix ? `${relPrefix}/${stem}` : stem;
+      try {
+        const content = await readFile(abs, 'utf8');
+        docs.push({ path: relPath, content, type });
+      } catch (err) {
+        warn(
+          `[clean-jsdoc-theme] could not read doc file '${abs}' — ${(err as Error).message}; skipping.`
+        );
+      }
+    }
+  };
+
+  await walk(root, '');
+
+  // Deterministic order so the manifest is stable build-to-build.
+  docs.sort((a, b) => a.path.localeCompare(b.path));
+  return docs;
+}
+
+/** The output of {@link resolveDocImages}: resolved docs + their image assets. */
+export interface ResolvedDocs {
+  docs: DocInput[];
+  files: OutputFile[];
+  inlineSvgs: Record<string, string>;
+}
+
+/** Markdown image: captures `![alt](`, the src, an optional `"title"`, and `)`. */
+const DOC_IMAGE_RE = /(!\[[^\]]*\]\()([^)\s]+)((?:\s+"[^"]*")?\))/g;
+
+/**
+ * Resolve the local images a doc references and route them through the same
+ * content-hashed `_assets/` pipeline as the JSDoc bridge. For each `![alt](src)`
+ * whose `src` points to a file on disk, the file is copied to
+ * `_assets/<base>.<hash><ext>` (cache-busted, deduped across docs) and the `src`
+ * is rewritten to the root-relative `/_assets/<base>.<hash><ext>`. A `src` is
+ * resolved relative to the project root when it starts with `/`, else relative to
+ * the doc's own directory; absolute (`http(s):`, `data:`), `#`-anchor, and
+ * unreadable srcs are left untouched (the last with a warning). SVGs are ALSO
+ * collected as inline markup (keyed by the rewritten src) so the renderer can drop
+ * them into the page — its `[data-theme="dark"]` styles then follow the toggle.
+ */
+export async function resolveDocImages(
+  docs: DocInput[],
+  docsDir: string,
+  warn: Warn
+): Promise<ResolvedDocs> {
+  if (docs.length === 0) return { docs, files: [], inlineSvgs: {} };
+  const root = resolvePath(docsDir);
+  const files: OutputFile[] = [];
+  const seenServed = new Set<string>();
+  const inlineSvgs: Record<string, string> = {};
+  // abs path → rewritten src (root-relative `/_assets/…`), or null if unreadable.
+  const cache = new Map<string, string | null>();
+
+  const resolveOne = async (rawSrc: string, docDir: string): Promise<string | null> => {
+    const src = rawSrc.trim();
+    if (!src || isServableUrl(src) || src.startsWith('#') || src.startsWith('data:')) return null;
+    const abs = src.startsWith('/') ? resolvePath(src.slice(1)) : resolvePath(docDir, src);
+    if (cache.has(abs)) return cache.get(abs) ?? null;
+    let bytes: Buffer;
+    try {
+      bytes = await readFile(abs);
+    } catch {
+      warn(
+        `[clean-jsdoc-theme] could not read doc image '${src}' (resolved '${abs}'); leaving it as-is.`
+      );
+      cache.set(abs, null);
+      return null;
+    }
+    const ext = extname(abs);
+    const served = `_assets/${basename(abs, ext) || 'asset'}.${contentHash(bytes)}${ext}`;
+    if (!seenServed.has(served)) {
+      seenServed.add(served);
+      files.push({ path: served, contents: bytes });
+    }
+    const href = '/' + served;
+    if (ext.toLowerCase() === '.svg') {
+      inlineSvgs[href] = bytes
+        .toString('utf8')
+        .replace(/<svg\b/, '<svg style="max-width:100%;height:auto;display:block"');
+    }
+    cache.set(abs, href);
+    return href;
+  };
+
+  const out: DocInput[] = [];
+  for (const doc of docs) {
+    const docDir = dirname(resolvePath(root, doc.path));
+    const map = new Map<string, string>();
+    for (const m of doc.content.matchAll(DOC_IMAGE_RE)) {
+      const src = m[2];
+      if (map.has(src)) continue;
+      const href = await resolveOne(src, docDir);
+      if (href) map.set(src, href);
+    }
+    if (map.size === 0) {
+      out.push(doc);
+      continue;
+    }
+    const content = doc.content.replace(DOC_IMAGE_RE, (full, pre, src, post) =>
+      map.has(src) ? `${pre}${map.get(src)}${post}` : full
+    );
+    out.push({ ...doc, content });
+  }
+  return { docs: out, files, inlineSvgs };
+}

--- a/packages/typedoc/src/options.ts
+++ b/packages/typedoc/src/options.ts
@@ -13,6 +13,8 @@
  *     "siteName": "My Library",
  *     "fonts": { "heading": "Fraunces", "body": "Spline Sans" },
  *     "sectionOrder": ["Classes", "Interfaces", "Enums", "Typedefs"],
+ *     "docs": "docs",
+ *     "docGroups": ["Guides"],
  *     "menu": [{ "id": "home", "title": "Home", "link": "/" }],
  *     "clubSidebarItems": true,
  *     "copyPage": true,
@@ -44,6 +46,12 @@ export interface CleanJsdocThemeBlock {
   fonts?: unknown;
   /** Ordered sidebar section labels (filters + orders the API sections). */
   sectionOrder?: unknown;
+  /** Prose-docs directory (Markdown/HTML) rendered into pages alongside the API. */
+  docs?: unknown;
+  /** Top-level doc-group display order (the sidebar sections built from docs). */
+  docGroups?: unknown;
+  /** Fallback group label for a doc with no group of its own. */
+  defaultDocGroup?: unknown;
   /** Full sidebar menu (takes precedence over `sectionOrder`). */
   menu?: unknown;
   /** Club prefix-grouped sidebar entries into subtrees. */
@@ -78,8 +86,9 @@ export function declareThemeOption(app: Application): void {
   const declaration: DeclarationOption = {
     name: OPTION_NAME,
     help:
-      'clean-jsdoc-theme options (siteName, fonts, sectionOrder, menu, ' +
-      'clubSidebarItems, copyPage, pageNav, playground, aiPrompt, footer, favicon, meta, strict).',
+      'clean-jsdoc-theme options (siteName, fonts, sectionOrder, docs, docGroups, ' +
+      'defaultDocGroup, menu, clubSidebarItems, copyPage, pageNav, playground, ' +
+      'aiPrompt, footer, favicon, meta, strict).',
     type: ParameterType.Object,
     defaultValue: {},
   };

--- a/packages/typedoc/src/write-site.ts
+++ b/packages/typedoc/src/write-site.ts
@@ -18,7 +18,12 @@ import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import { dirname, extname, resolve as resolvePath } from 'node:path';
 import salty from '@jsdoc/salty';
 import { generateSite } from '@clean-jsdoc-theme/setu';
-import type { MenuItem, PlaygroundSiteConfig, SourceFileInput } from '@clean-jsdoc-theme/setu';
+import type {
+  DocInput,
+  MenuItem,
+  PlaygroundSiteConfig,
+  SourceFileInput,
+} from '@clean-jsdoc-theme/setu';
 import { render, runPagefindAgainstDir } from '@clean-jsdoc-theme/dwar';
 import type {
   CopyPageAction,
@@ -42,6 +47,7 @@ import {
 import type { FontSet, PlaygroundProvider, TDoclet, ValidatedFonts } from '@clean-jsdoc-theme/utils';
 import { reflectionsToDoclets } from './reflection-to-doclets';
 import { markdownToHtml, partsToMarkdown } from './comment';
+import { collectDocs, resolveDocImages } from './docs';
 import { writeOutputFiles } from './write-output-files';
 import { KNOWN_NON_THEME_KEYS, readThemeOption } from './options';
 import type { CleanJsdocThemeBlock } from './options';
@@ -599,6 +605,23 @@ export async function writeSite(
   const pkg = await resolvePkg(project);
   const sources = await collectSourceFiles(doclets, logger);
 
+  // Prose docs (`cleanJsdocTheme.docs` directory) → pages at clean slugs, with
+  // their local images routed through the `_assets/` pipeline (the bridge is the
+  // I/O layer; setu/dwar stay disk-free). `docGroups` orders the doc-group
+  // sidebar sections; `defaultDocGroup` labels docs with no group of their own.
+  const docsDir =
+    typeof block.docs === 'string' && block.docs.trim().length > 0 ? block.docs.trim() : undefined;
+  const warn = (msg: string): void => logger.warn(msg);
+  const resolvedDocs = docsDir
+    ? await resolveDocImages(await collectDocs(docsDir, warn), docsDir, warn)
+    : { docs: [] as DocInput[], files: [] as OutputFile[], inlineSvgs: {} as Record<string, string> };
+  const docs = resolvedDocs.docs;
+  const docGroups = normalizeSectionOrder(block.docGroups);
+  const defaultDocGroup =
+    typeof block.defaultDocGroup === 'string' && block.defaultDocGroup.trim().length > 0
+      ? block.defaultDocGroup.trim()
+      : undefined;
+
   // Sidebar config from the block: `menu` (full control) > `sectionOrder`.
   const sectionOrder = normalizeSectionOrder(block.sectionOrder);
   const menu = normalizeMenu(block.menu);
@@ -610,6 +633,9 @@ export async function writeSite(
     ...(pkg ? { pkg } : {}),
     ...(readme ? { readme } : {}),
     ...(sources.length > 0 ? { sources } : {}),
+    ...(docs.length > 0 ? { docs } : {}),
+    ...(docGroups ? { docGroups } : {}),
+    ...(defaultDocGroup ? { defaultDocGroup } : {}),
     ...(sectionOrder ? { sectionOrder } : {}),
     ...(menu ? { menu } : {}),
     ...(clubSidebarItems ? { clubSidebarItems } : {}),
@@ -677,9 +703,19 @@ export async function writeSite(
     },
     destination,
     islandCacheDir,
+    // SVGs referenced by docs are inlined (theme-toggle-aware) rather than
+    // `<img>`-ed; an empty map is a no-op, so a docs-less build is unaffected.
+    ...(Object.keys(resolvedDocs.inlineSvgs).length > 0
+      ? { inlineSvgs: resolvedDocs.inlineSvgs }
+      : {}),
   });
 
-  const outputFiles = [...result.files, ...logoFiles, ...(favicon?.files ?? [])];
+  const outputFiles = [
+    ...result.files,
+    ...logoFiles,
+    ...(favicon?.files ?? []),
+    ...resolvedDocs.files,
+  ];
   await writeOutputFiles(destination, outputFiles);
 
   // Next.js-style build report: where the files landed, page/asset counts, and

--- a/packages/utils/src/config/opts-schema.ts
+++ b/packages/utils/src/config/opts-schema.ts
@@ -1,7 +1,7 @@
 /**
  * zod schemas for the theme option surface — the recognized `siteName`,
  * `fonts`, `menu`, `copyPage`, `pageNav`, `playground`, `sectionOrder`,
- * `docGroups`, `defaultDocGroup`, `clubSidebarItems`, `aiPrompt`, and
+ * `docs`, `docGroups`, `defaultDocGroup`, `clubSidebarItems`, `aiPrompt`, and
  * `basePath` opts the JSDoc bridge accepts.
  *
  * These mirror the theme-relevant subset of `clean-jsdoc-theme`'s `JSDocOpts`
@@ -201,6 +201,7 @@ export const THEME_OPT_KEYS = [
   'pageNav',
   'playground',
   'sectionOrder',
+  'docs',
   'docGroups',
   'defaultDocGroup',
   'clubSidebarItems',


### PR DESCRIPTION
Fixes the reporter's blocker: the TypeDoc plugin warned `unknown option "docs"` and generated no prose, even though the JSDoc bridge has long supported a `docs` directory of Markdown/HTML.

## Root cause

- `docs` was **not** in the recognized theme-opt surface (`THEME_OPT_KEYS`), so the TypeDoc bridge's `unknownKeyPolicy: 'warn-all'` flagged it. (`docGroups`/`defaultDocGroup` were already recognized.)
- More importantly, `write-site.ts` never **read** `docs` — there was no code path to walk the directory or feed prose pages into `generateSite`. The feature simply didn't exist on the TypeDoc side.
- `readme`: this is a **native top-level TypeDoc option** (`"readme": "README.md"`). The reporter's `unknown option "readme"` came from nesting it inside the `cleanJsdocTheme` block — it belongs at the top level (the example already uses it there). No change needed.

## What changed

- **`utils`** — add `docs` to `THEME_OPT_KEYS` so it's a recognized key everywhere.
- **`packages/typedoc/src/docs.ts`** (new) — `collectDocs` + `resolveDocImages`, copied from the JSDoc bridge per the repo's "bridges don't cross-import" convention, but routing warnings through TypeDoc's `logger.warn`. Walks the dir into `DocInput[]` (POSIX, extension-stripped slugs; frontmatter preserved), and routes referenced local images through the content-hashed `_assets/` pipeline (SVGs additionally collected for theme-toggle-aware inlining).
- **`options.ts`** — declare `docs`/`docGroups`/`defaultDocGroup` on the block + help text + doc example.
- **`write-site.ts`** — wire them into `generateSite` (`docs`/`docGroups`/`defaultDocGroup`), and pass the doc image assets + `inlineSvgs` through `render` (a docs-less build stays byte-identical).

Behaviour now mirrors the JSDoc bridge: filesystem layout drives URL + sidebar group, per-file frontmatter (`title`/`group`/`order`/`slug`/`hidden`) overrides, and a root `index.md` becomes the home page (over the README).

## Verification

- New `docs.test.ts` (6 cases): tree walk + slug shape, noise/dot-dir skip, missing-dir resilience, image → hashed `_assets/` rewrite, SVG inline collection, remote/data/anchor srcs left untouched. Full typedoc suite: 38 passed.
- `utils`/`typedoc` typecheck + lint clean.
- End-to-end: `examples/typedoc-basic` now ships a `docs/` tree — TypeDoc exits 0, **no** unknown-option warning, and emits `/` (home from `docs/index.md`, overriding the README) and `/guides/getting-started` in a **Guides** sidebar group.

Fixes #334