### PR TITLE
fix(dwar): harden escapeStrayBraces against stray backticks (#333)

### DIFF
--- a/packages/dwar/src/__tests__/mdx.test.ts
+++ b/packages/dwar/src/__tests__/mdx.test.ts
@@ -54,4 +54,35 @@ describe('escapeStrayBraces', () => {
     const out = escapeStrayBraces(preprocessJsdocInlineTags('{@link base#x} and {base#y}'));
     expect(out).toBe('`@link base#x` and \\{base#y\\}');
   });
+
+  it('allows a code span to cross a single line break', () => {
+    // CommonMark code spans may span lines — just not a blank line.
+    const out = escapeStrayBraces('a `code {x}\nmore {y}` b');
+    expect(out).toBe('a `code {x}\nmore {y}` b'); // braces inside the span untouched
+  });
+
+  it('does not let an unbalanced backtick swallow a later brace across a blank line', () => {
+    // issue #333 / dwv: an odd backtick run desyncs naive pairing. The stray
+    // backtick on the first line has no equal-length partner before the blank
+    // line, so it stays literal and the brace in the next paragraph is escaped.
+    const out = escapeStrayBraces('open `unclosed tick\n\nlater {x: 1} brace');
+    expect(out).toContain('later \\{x: 1\\} brace');
+  });
+
+  it('reproduces the dwv splitKeyValueString shape: braces escape past a stray tick', () => {
+    // The real failure: line 1 opens a backtick that pairs with the FIRST tick on
+    // line 2 (single line break, allowed); the SECOND tick on line 2 is then a
+    // lone tick. Across the following blank line, a separate comment's object
+    // example must still be escaped, not swallowed as code.
+    const src = [
+      'Split key/value string: `key0=val00&key0=val01&key1=val10',
+      '  will return `{key0 : [val00, val01], key1 : val1}`.',
+      '',
+      'returns { base : root, query : [ key0 : [val00] ] }',
+    ].join('\n');
+    const out = escapeStrayBraces(src);
+    // The object example after the blank line is escaped (would otherwise be an
+    // MDX expression → acorn failure).
+    expect(out).toContain('returns \\{ base : root, query : [ key0 : [val00] ] \\}');
+  });
 });

--- a/packages/dwar/src/__tests__/render.test.ts
+++ b/packages/dwar/src/__tests__/render.test.ts
@@ -757,14 +757,14 @@ describe('render() — issue #333: render-error diagnostics', () => {
     expect(err.snippet).toContain(`${err.line} |`);
   });
 
-  // The exact failure from issue #333: an aggregated Globals page where one
-  // symbol's doc comment has an unbalanced inline-code backtick straddling a
-  // blank line, with a `{...}` between the ticks. The brace-escaping pre-pass
-  // treats the whole run as code (so the brace survives), but a Markdown code
-  // span can't cross a paragraph break — so MDX reads `{...}` as a flow
-  // expression and acorn rejects it. This is the v4→v5 trap: v4 rendered the
-  // description as raw HTML and never choked.
-  it('reproduces "Could not parse expression with acorn" and locates it', async () => {
+  // issue #333 (dwv): an aggregated Globals page where one symbol's doc comment
+  // has an unbalanced inline-code backtick straddling a blank line, with a `{...}`
+  // between the ticks. This used to abort the page ("Could not parse expression
+  // with acorn") because escapeStrayBraces let the stray backtick swallow the
+  // brace as "code". escapeStrayBraces now mirrors CommonMark (a code span can't
+  // cross a blank line), so the brace is escaped and the page renders — this is
+  // the regression guard for that fix.
+  it('renders an aggregated page with an unbalanced backtick + brace (issue #333)', async () => {
     const m = makeManifest();
     m.pages.push({
       slug: 'global',
@@ -781,14 +781,8 @@ describe('render() — issue #333: render-error diagnostics', () => {
       headings: [],
     });
     const result = await render(m, { theme: minimalTheme });
-    const err = result.errors!.find((e) => e.slug === 'global')!;
-    expect(err.message).toBe('Could not parse expression with acorn');
-    expect(typeof err.line).toBe('number');
-    // The snippet shows the offending line so the symbol is locatable on a big
-    // aggregated page — the whole point of the issue #333 diagnostics fix.
-    expect(err.snippet).toContain('Pass `{ port: 8080 } to override just the port');
-    // And the page is skipped, never thrown — the Globals page just goes missing,
-    // which is exactly why the reporter saw "no globals".
-    expect(result.files.map((f) => f.path)).not.toContain('global/index.html');
+    // No render failure, and the page is emitted (it used to be skipped).
+    expect(result.errors?.some((e) => e.slug === 'global')).toBeFalsy();
+    expect(result.files.map((f) => f.path)).toContain('global/index.html');
   });
 });

--- a/packages/dwar/src/mdx.ts
+++ b/packages/dwar/src/mdx.ts
@@ -133,6 +133,16 @@ export function preprocessJsdocInlineTags(source: string): string {
  * left untouched — MDX doesn't parse expressions there, and escaping would leak
  * visible backslashes. Run this AFTER {@link preprocessJsdocInlineTags} so the
  * inline-code spans it produces for `{@link}` are protected here.
+ *
+ * The inline-code matcher mirrors CommonMark's rule that a code span **cannot
+ * contain a blank line** (a code span lives within one paragraph). This matters
+ * on a big aggregated page (e.g. Globals): a single unbalanced backtick in one
+ * doc comment must not pair with a far-away backtick in another, swallowing
+ * everything between as "code" and leaving its braces un-escaped — MDX, which
+ * stops a code span at the blank line, would then read those braces as a JS
+ * expression and abort the page (issue #333, dwv `splitKeyValueString`). So a
+ * stray backtick that has no equal-length partner before the next blank line is
+ * left literal, and the braces around it are escaped like any other prose.
  */
 export function escapeStrayBraces(source: string): string {
   // Keep leading YAML frontmatter verbatim (braces there are YAML, not MDX).
@@ -140,9 +150,13 @@ export function escapeStrayBraces(source: string): string {
   const prefix = fm ? fm[0] : '';
   const body = fm ? source.slice(fm[0].length) : source;
 
-  // Single scan: a fenced code block, OR an inline code span (matched backtick
-  // runs), OR a lone brace. Code matches pass through; lone braces get escaped.
-  const re = /(```[\s\S]*?```|~~~[\s\S]*?~~~)|(`+)(?:[\s\S]*?)\2|([{}])/g;
+  // Single scan: a fenced code block, OR an inline code span, OR a lone brace.
+  // Code matches pass through; lone braces get escaped. The inline-code content
+  // `(?:[^\n]|\n(?![ \t\r]*\n))*?` allows single line breaks (CommonMark code
+  // spans may span lines) but never a blank line — so an unclosed backtick can't
+  // run past a paragraph break and mis-swallow another comment's braces.
+  const re =
+    /(```[\s\S]*?```|~~~[\s\S]*?~~~)|(`+)(?:[^\n]|\n(?![ \t\r]*\n))*?\2|([{}])/g;
   const escaped = body.replace(re, (m, _fence, _ticks, brace) => (brace ? `\\${brace}` : m));
   return prefix + escaped;
 }


### PR DESCRIPTION
Follow-up to #333. The render-error diagnostics from #335 helped locate the failure in the reporter's project (dwv); this hardens the underlying cause so it can't happen.

## Root cause (debugged in dwv)

dwv's Globals page failed with `Could not parse expression with acorn`. Tracing it with the new diagnostics led to one doc comment with an **unclosed inline-code backtick** (`splitKeyValueString`):

```js
 * Split key/value string: `key0=val00&key0=val01&key1=val10   // ← backtick never closed
 *   will return `{key0 : [val00, val01], key1 : val1}`.
```

`escapeStrayBraces` matched inline code with `` (`+)(?:[\s\S]*?)\2 `` — which **crosses blank lines**. On the giant aggregated Globals page that stray backtick paired with a far-away backtick in *another* comment and swallowed everything between as "code", so the braces in that span were left un-escaped. MDX, which ends a code span at the blank line, then read those braces (e.g. `splitUri`'s `{ base : root, … }`) as a JS expression and aborted the whole page.

## Fix

Mirror CommonMark: **a code span can't contain a blank line.** The inline-code content now allows single line breaks but never a blank line:

```
(`+)(?:[^\n]|\n(?![ \t\r]*\n))*?\2
```

So a stray backtick with no equal-length partner before the next paragraph break is left literal, and the surrounding braces are escaped like any other prose — one bad comment can no longer cascade across a page.

## Verification

- New `escapeStrayBraces` unit tests: a code span may cross a single line break; an unbalanced backtick does **not** swallow a brace across a blank line; and a regression case built from the exact dwv `splitKeyValueString` shape.
- The #333 render test that used to reproduce the acorn failure via braces now asserts the page **renders cleanly** (regression guard for this fix). Full dwar suite: 108 passed; typecheck + lint clean.
- End-to-end: built the real **dwv** project with this change — the Globals page now renders, no skipped pages.

Note: this is the "improve `escapeStrayBraces` robustness" item the #333 design doc deferred as a separate effort. It does not change the skip-don't-throw resilience or the diagnostics.

Refs #333