### PR TITLE
fix(setu): hyperlink type names to the symbols they reference (v4 parity)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -213,9 +213,17 @@ stays as a final safety net so any tag that still reaches MDX compile can't brea
 the page. The resolver also has a **unique short-name fallback**: a bare authored
 name (`{@link BaseEntity}`) resolves to its symbol only when that short name is
 unambiguous across the whole registry — ambiguous names refuse to resolve rather
-than guess. Known v1 limitation (see `docs/plan-link-resolution.md`): member
-anchors are bare `slugifyHeading(name)` without the per-page dedup counter, so a
-member whose heading slug collides on its page may get a slightly-off anchor.
+than guess. The same resolver also links **type names** (v4 parity): every
+parameter / property / return / throws type, a field's `Type:` line, and the
+`@augments`/`@implements`/`@mixes` relations are tokenized (`linkifyTypeExpression`
+in `mdast/doclet.ts`) and each identifier that resolves to a documented symbol
+becomes an anchor — `@param {BaseEntity}` links to its page, a member type to its
+`slug#anchor` — while built-ins (`string`, `Array`) and unresolved names stay
+inert code/text, byte-identical to before (no resolver → no links, so the
+localization-extract path is unaffected). Known v1 limitation (see
+`docs/plan-link-resolution.md`): member anchors are bare `slugifyHeading(name)`
+without the per-page dedup counter, so a member whose heading slug collides on its
+page may get a slightly-off anchor.
 
 Source files are a third output, gated by the bridge's `outputSourceFiles` flag
 (default on). When enabled, every documented source file becomes a hidden

--- a/packages/aadesh/socket.yml
+++ b/packages/aadesh/socket.yml
@@ -1,0 +1,13 @@
+# Folder-scoped Socket config for @clean-jsdoc-theme/aadesh.
+#
+# aadesh is the theme's i18n CLI (published binary `clean-jsdoc`). It legitimately
+# spawns the real build pipeline as a child process — in *extract* mode to harvest
+# translatable strings, and once per locale in *build* mode to stamp translations
+# back in. That child_process use is the whole point of the tool, not a risk, so
+# `shellAccess` is disabled here only. It stays ENABLED everywhere else in the repo
+# (the root socket.yml does not disable it), so the rendering packages still get
+# the check.
+version: 2
+
+issueRules:
+  shellAccess: false

--- a/packages/clean-jsdoc-theme/src/publish.ts
+++ b/packages/clean-jsdoc-theme/src/publish.ts
@@ -7,7 +7,7 @@ import { mkdir, readFile, readdir, writeFile } from 'node:fs/promises';
 import { readFileSync } from 'node:fs';
 import { createHash } from 'node:crypto';
 import { basename, dirname, extname, join as joinPath, resolve as resolvePath } from 'node:path';
-import { pathToFileURL, fileURLToPath } from 'node:url';
+import { pathToFileURL } from 'node:url';
 import type {
   CopyPageAction,
   CopyPageConfig,
@@ -35,24 +35,13 @@ import { writeOutputFiles } from './write-output-files';
 // read it.
 const JSDOC_TUTORIAL_TYPE_MARKDOWN = 2;
 
-// Absolute path of the running module. The `new Function` wrapper around
-// `import.meta` keeps the CJS parser from rejecting it.
+// Absolute path of the running module. `__filename` is native in the CJS build
+// and injected into the ESM build by tsup's `shims` option (from
+// import.meta.url), so this resolves in both without an eval/`new Function` shim.
 function anchorPath(): string {
   if (typeof __filename === 'string') return __filename;
-  try {
-    const getEsmUrl = new Function(
-      'try { return import.meta && import.meta.url; } catch { return undefined; }'
-    ) as () => string | undefined;
-    const url = getEsmUrl();
-    if (typeof url === 'string' && url.startsWith('file://')) {
-      return fileURLToPath(url);
-    }
-  } catch {
-    // fall through to the throw below.
-  }
   throw new Error(
-    'clean-jsdoc-theme: could not determine the running module path ' +
-      '(neither __filename nor import.meta.url resolved).'
+    'clean-jsdoc-theme: could not determine the running module path (__filename is unavailable).'
   );
 }
 

--- a/packages/clean-jsdoc-theme/tsup.config.ts
+++ b/packages/clean-jsdoc-theme/tsup.config.ts
@@ -7,4 +7,8 @@ export default defineConfig({
   dts: true,
   clean: true,
   sourcemap: true,
+  // Inject __filename/__dirname into the ESM output (derived from
+  // import.meta.url) so the CJS-first module-path resolution in publish.ts works
+  // in both builds — no `new Function('import.meta.url')` eval shim needed.
+  shims: true,
 });

--- a/packages/dwar/src/__tests__/mdx.test.ts
+++ b/packages/dwar/src/__tests__/mdx.test.ts
@@ -90,6 +90,16 @@ describe('escapeStrayBraces', () => {
     // MDX expression → acorn failure).
     expect(out).toContain('returns \\{ base : root, query : [ key0 : [val00] ] \\}');
   });
+
+  it('treats a longer backtick run inside a span as content, not a premature close', () => {
+    // The ``` is literal content of the `…` span; a brace OUTSIDE still escapes.
+    expect(escapeStrayBraces('see ` ```x ` then {y}')).toBe('see ` ```x ` then \\{y\\}');
+  });
+
+  it('ignores a backslash-escaped backtick (literal, not a span opener)', () => {
+    // `\`` is a literal backtick, so it does not open a span — the {y} still escapes.
+    expect(escapeStrayBraces('a \\` then {y}')).toBe('a \\` then \\{y\\}');
+  });
 });
 
 describe('findStrayBackticks', () => {
@@ -113,6 +123,22 @@ describe('findStrayBackticks', () => {
   it('ignores backticks inside fenced code blocks and frontmatter', () => {
     const src = '---\ntag: `x\n---\n\n```\nlone ` inside fence\n```\n\nclean prose';
     expect(findStrayBackticks(src)).toEqual([]);
+  });
+
+  it('does NOT flag a longer backtick run inside a code span (CommonMark)', () => {
+    // Regression: `` ` ```iframe ` `` is a valid single-backtick span whose content
+    // is the literal ```iframe — the inner ``` must not be read as a premature
+    // closer that leaves dangling backticks (the markdown-examples tutorial case).
+    expect(findStrayBackticks('Use an ` ```iframe ` fenced block')).toEqual([]);
+    // A double-backtick span containing a single backtick is also balanced.
+    expect(findStrayBackticks('the `` ` `` character')).toEqual([]);
+  });
+
+  it('ignores backslash-escaped backticks (literal, not delimiters)', () => {
+    // e.g. a table cell that displays the backtick character, or a trailing
+    // escaped backtick after a balanced span — neither is a real delimiter.
+    expect(findStrayBackticks('| Backtick | \\` |')).toEqual([]);
+    expect(findStrayBackticks('span `x` then a literal \\` backtick')).toEqual([]);
   });
 
   it('flags the orphan tick in the dwv splitKeyValueString shape', () => {

--- a/packages/dwar/src/mdx.ts
+++ b/packages/dwar/src/mdx.ts
@@ -154,9 +154,13 @@ export function escapeStrayBraces(source: string): string {
   // Code matches pass through; lone braces get escaped. The inline-code content
   // `(?:[^\n]|\n(?![ \t\r]*\n))*?` allows single line breaks (CommonMark code
   // spans may span lines) but never a blank line — so an unclosed backtick can't
-  // run past a paragraph break and mis-swallow another comment's braces.
+  // run past a paragraph break and mis-swallow another comment's braces. A
+  // delimiter run is bounded by `(?<![`\\])…(?!`)` so it (a) closes only on a
+  // *maximal* run of exactly N — a longer run inside (e.g. ``` in a `…` span) is
+  // literal content — and (b) ignores a backslash-escaped backtick (`\``), which
+  // is a literal backtick per CommonMark, not a delimiter.
   const re =
-    /(```[\s\S]*?```|~~~[\s\S]*?~~~)|(`+)(?:[^\n]|\n(?![ \t\r]*\n))*?\2|([{}])/g;
+    /(```[\s\S]*?```|~~~[\s\S]*?~~~)|(?<![`\\])(`+)(?:[^\n]|\n(?![ \t\r]*\n))*?(?<![`\\])\2(?!`)|([{}])/g;
   const escaped = body.replace(re, (m, _fence, _ticks, brace) => (brace ? `\\${brace}` : m));
   return prefix + escaped;
 }
@@ -185,9 +189,13 @@ export function findStrayBackticks(source: string): StrayBacktick[] {
   const out: StrayBacktick[] = [];
   // Skip leading YAML frontmatter (backticks there aren't MDX inline code).
   const fm = /^---\n[\s\S]*?\n---\n/.exec(source);
-  // Fenced block | balanced inline span (group 3 = its ticks) | leftover run (group 4).
+  // Fenced block | balanced inline span (group 3 = its ticks) | leftover run
+  // (group 4). A delimiter run is bounded by `(?<![`\\])…(?!`)`: it closes only on
+  // a maximal run of exactly N (a longer run inside a span, e.g. ``` in
+  // `` ` ```x ` ``, is literal content) and ignores backslash-escaped backticks
+  // (`\``, a literal backtick) — both match CommonMark, avoiding false strays.
   const re =
-    /(```[\s\S]*?```|~~~[\s\S]*?~~~)|((`+)(?:[^\n]|\n(?![ \t\r]*\n))*?\3)|(`+)/g;
+    /(```[\s\S]*?```|~~~[\s\S]*?~~~)|(?<![`\\])((`+)(?:[^\n]|\n(?![ \t\r]*\n))*?(?<![`\\])\3(?!`))|(?<![`\\])(`+)/g;
   re.lastIndex = fm ? fm[0].length : 0;
   let m: RegExpExecArray | null;
   while ((m = re.exec(source)) !== null) {

--- a/packages/setu/src/__tests__/link-resolution.test.ts
+++ b/packages/setu/src/__tests__/link-resolution.test.ts
@@ -241,3 +241,90 @@ describe('container merge — same-slug class doclets are merged, not dropped', 
     expect(workerBody).toContain(`(/${slug})`);
   });
 });
+
+describe('link resolution — type names link to the symbol they reference (v4 parity)', () => {
+  /**
+   * `Box` references the documented class `Widget` from every type-bearing slot:
+   * a constructor param, a method param + return, an instance field's type, and
+   * the `@augments` relation. Each must hyperlink to `Widget`'s page (`/widget`).
+   * A built-in (`string`) type must NOT link — it has no registered symbol.
+   */
+  function typeRefCollection(): TJSDocSaltyCollection<TDoclet> {
+    return makeCollection([
+      {
+        kind: 'class',
+        name: 'Widget',
+        longname: 'Widget',
+        scope: 'global',
+        comment: '/** A widget. */',
+        classdesc: 'A widget.',
+      },
+      {
+        kind: 'class',
+        name: 'Box',
+        longname: 'Box',
+        scope: 'global',
+        comment: '/** A box. @augments Widget @param {Widget} seed */',
+        classdesc: 'A box.',
+        augments: ['Widget'],
+        params: [{ name: 'seed', type: { names: ['Widget'] }, description: 'Initial widget.' }],
+      },
+      {
+        kind: 'member',
+        name: 'current',
+        longname: 'Box#current',
+        memberof: 'Box',
+        scope: 'instance',
+        comment: '/** Current widget. */',
+        description: 'Current widget.',
+        type: { names: ['Widget'] },
+      },
+      {
+        kind: 'function',
+        name: 'wrap',
+        longname: 'Box#wrap',
+        memberof: 'Box',
+        scope: 'instance',
+        comment: '/** Wrap. */',
+        description: 'Wrap a widget.',
+        params: [
+          { name: 'item', type: { names: ['Widget'] }, description: 'The widget.' },
+          { name: 'label', type: { names: ['string'] }, description: 'A label.' },
+        ],
+        returns: [{ type: { names: ['Widget'] }, description: 'The wrapped widget.' }],
+      },
+    ]);
+  }
+
+  it('links a constructor param type (plain-text style) to the symbol page', () => {
+    const body = bodyOf(generateSite(typeRefCollection()), 'Box');
+    // The Parameters list renders the type as plain text, so the link has a
+    // plain-text label.
+    expect(body).toContain('[Widget](/widget)');
+  });
+
+  it('links a method param and return type (code style) to the symbol page', () => {
+    const body = bodyOf(generateSite(typeRefCollection()), 'Box');
+    // Returns/throws + a member field render the type as monospaced code, so the
+    // link wraps an inline-code label.
+    expect(body).toContain('[`Widget`](/widget)');
+  });
+
+  it('links an instance field `Type:` to the symbol page', () => {
+    const body = bodyOf(generateSite(typeRefCollection()), 'Box');
+    expect(body).toContain('**Type**');
+    expect(body).toContain('[`Widget`](/widget)');
+  });
+
+  it('links the @augments relation to the base class', () => {
+    const body = bodyOf(generateSite(typeRefCollection()), 'Box');
+    expect(body).toContain('[`Widget`](/widget)');
+    expect(body).toContain('Extends');
+  });
+
+  it('leaves a built-in type unlinked', () => {
+    const body = bodyOf(generateSite(typeRefCollection()), 'Box');
+    expect(body).not.toContain('[string]');
+    expect(body).not.toContain('[`string`]');
+  });
+});

--- a/packages/setu/src/mdast/class-view.ts
+++ b/packages/setu/src/mdast/class-view.ts
@@ -1,7 +1,7 @@
-import type { Root, RootContent } from 'mdast';
+import type { PhrasingContent, Root, RootContent } from 'mdast';
 import { ClassMember, ClassView, ContainerView, MemberBuckets } from '../class-view';
 import { slugifyHeading, TDocletParam } from '@clean-jsdoc-theme/utils';
-import { h, hr, inlineCode, memberHeading, memberMeta, p, root, strong, text } from './builders';
+import { h, hr, inlineCode, link, memberHeading, memberMeta, p, root, strong, text } from './builders';
 import {
   docletBlocks,
   DocletBlocksOptions,
@@ -154,9 +154,14 @@ export function memberSections(
 
 /**
  * "Extends" / "Implements" / "Mixes" lines for a class. Returns the blocks
- * that apply; empty if none.
+ * that apply; empty if none. Each referenced symbol hyperlinks to its page when
+ * `resolveLink` is supplied and the name resolves — otherwise it stays inert
+ * code, byte-identical to before.
  */
-export function classRelationsBlocks(doclet: ClassView['doclet']): RootContent[] {
+export function classRelationsBlocks(
+  doclet: ClassView['doclet'],
+  resolveLink?: DocletBlocksOptions['resolveLink']
+): RootContent[] {
   const lines: { label: string; refs: readonly string[] | undefined }[] = [
     { label: 'Extends', refs: doclet.augments },
     { label: 'Implements', refs: doclet.implements },
@@ -166,12 +171,11 @@ export function classRelationsBlocks(doclet: ClassView['doclet']): RootContent[]
   return lines
     .filter(({ refs }) => refs && refs.length > 0)
     .map(({ label, refs }) => {
-      const children: ReturnType<typeof inlineCode | typeof text | typeof strong>[] = [
-        strong(text(`${label}: `)),
-      ];
+      const children: PhrasingContent[] = [strong(text(`${label}: `))];
       refs!.forEach((r, i) => {
         if (i > 0) children.push(text(', '));
-        children.push(inlineCode(r));
+        const resolved = resolveLink?.(r) ?? null;
+        children.push(resolved && !resolved.external ? link(resolved.href, inlineCode(r)) : inlineCode(r));
       });
       return p(...children);
     });
@@ -195,7 +199,7 @@ export function containerViewToMdast(
   blocks.push(h(pageLevel, text(view.doclet.name ?? view.doclet.longname ?? 'Class')));
 
   // Extends/Implements/Mixes
-  blocks.push(...classRelationsBlocks(view.doclet));
+  blocks.push(...classRelationsBlocks(view.doclet, options.resolveLink));
 
   // Source link for the class declaration itself, when it resolves.
   const classSource = sourceLinkBlock(view.doclet, options);
@@ -234,7 +238,7 @@ export function containerViewToMdast(
     // member-level params on the same longname.
     const ctorParams = paramsList(
       view.constructorParams,
-      { slots: options.slots, longname: view.doclet.longname },
+      { slots: options.slots, longname: view.doclet.longname, resolveLink: options.resolveLink },
       'constructor.params'
     );
     // The separately-documented constructor description (only when a class has

--- a/packages/setu/src/mdast/doclet.ts
+++ b/packages/setu/src/mdast/doclet.ts
@@ -44,6 +44,84 @@ export function typeExpressionString(type: TDocletTypeProperty | undefined): str
   return type.names.join(' | ');
 }
 
+type LinkResolver = (target: string) => ResolvedLink | null;
+
+/**
+ * Identifier-path token inside a type expression: a run of word chars plus the
+ * JSDoc namepath separators (`.` `~` `#` `:` `/`) and `$`. Structural syntax —
+ * `< > ( ) [ ] | , ? ! * = space` — falls in the gaps between matches, so
+ * `Array.<MyClass> | null` yields the candidate tokens `Array.`, `MyClass`,
+ * `null` (the `.` after `Array` rides along and simply fails to resolve).
+ */
+const TYPE_TOKEN_RE = /[\w$./~#:]+/g;
+
+/**
+ * Render a type expression string as phrasing content, hyperlinking each token
+ * that resolves to a documented symbol — restoring the v4 behaviour where a
+ * `@param {MyClass}` type linked to the `MyClass` page (members resolve to their
+ * `slug#anchor` too). `style` picks the look of the non-link/link text: `'code'`
+ * for the monospaced contexts (returns, the "Type" field) and `'text'` for the
+ * plain-text parenthetical in the Parameters list.
+ *
+ * Stays byte-identical to the old single-node rendering whenever nothing links:
+ * with no resolver, or when no token resolves, it returns one `inlineCode`/`text`
+ * node holding the whole string — so the localization-extract path and any
+ * resolver-less caller are unaffected.
+ */
+function linkifyTypeExpression(
+  s: string,
+  resolveLink: LinkResolver | undefined,
+  style: 'code' | 'text'
+): PhrasingContent[] {
+  const base = style === 'code' ? inlineCode : text;
+  if (!resolveLink) return [base(s)];
+
+  const out: PhrasingContent[] = [];
+  let cursor = 0;
+  let pending = '';
+  let linked = false;
+  const flush = (): void => {
+    if (pending !== '') {
+      out.push(base(pending));
+      pending = '';
+    }
+  };
+
+  TYPE_TOKEN_RE.lastIndex = 0;
+  let match = TYPE_TOKEN_RE.exec(s);
+  while (match) {
+    const token = match[0];
+    const resolved = resolveLink(token);
+    if (resolved && !resolved.external) {
+      pending += s.slice(cursor, match.index);
+      flush();
+      out.push(link(resolved.href, base(token)));
+      linked = true;
+    } else {
+      pending += s.slice(cursor, match.index) + token;
+    }
+    cursor = match.index + token.length;
+    match = TYPE_TOKEN_RE.exec(s);
+  }
+  pending += s.slice(cursor);
+  flush();
+
+  return linked ? out : [base(s)];
+}
+
+/**
+ * Type expression of a doclet as link-aware phrasing content, or `null` when the
+ * doclet carries no type. See {@link linkifyTypeExpression} for the link rules.
+ */
+function typeExpressionPhrasing(
+  type: TDocletTypeProperty | undefined,
+  resolveLink: LinkResolver | undefined,
+  style: 'code' | 'text'
+): PhrasingContent[] | null {
+  if (!type || !type.names || type.names.length === 0) return null;
+  return linkifyTypeExpression(type.names.join(' | '), resolveLink, style);
+}
+
 // ── Description ─────────────────────────────────────────────────────────────
 
 /**
@@ -330,6 +408,12 @@ export function relationsBlocks(doclet: TDoclet): RootContent[] {
 export interface ParamSlotCtx {
   slots?: SlotResolver;
   longname?: string;
+  /**
+   * Registry resolver for hyperlinking type names (param/return/property types)
+   * to the page/anchor of the symbol they reference. Omitted → types render as
+   * inert code/text, byte-identical to before.
+   */
+  resolveLink?: LinkResolver;
 }
 
 /**
@@ -427,9 +511,9 @@ function typedDescriptionInline(
   fieldPrefix: string,
   index: number
 ) {
-  const out = [];
-  const t = typeExpressionString(item.type);
-  if (t) out.push(inlineCode(t));
+  const out: PhrasingContent[] = [];
+  const typeNodes = typeExpressionPhrasing(item.type, ctx?.resolveLink, 'code');
+  if (typeNodes) out.push(...typeNodes);
   // No name on a return/throws entry → key by position.
   const desc = descriptionInline(item.description, ctx, fieldPrefix, String(index));
   if (desc.length > 0) {
@@ -483,15 +567,25 @@ function paramListItem(
 
   if (param.name) line.push(inlineCode(param.name));
 
-  const flags: string[] = [];
-  const t = typeExpressionString(param.type);
-  if (t) flags.push(t);
-  if (param.optional) flags.push('optional');
+  // The parenthetical is `(type, optional, default: value)`. The type is the
+  // only linkable piece, so it renders as phrasing (a plain-text link when it
+  // resolves) while optional/default stay flat text — concatenating to the same
+  // string as before when nothing links.
+  const typeNodes = typeExpressionPhrasing(param.type, ctx?.resolveLink, 'text');
+  const trailingFlags: string[] = [];
+  if (param.optional) trailingFlags.push('optional');
   if (param.defaultvalue !== undefined)
-    flags.push(`default: ${JSON.stringify(param.defaultvalue)}`);
-  if (flags.length > 0) {
+    trailingFlags.push(`default: ${JSON.stringify(param.defaultvalue)}`);
+  if (typeNodes || trailingFlags.length > 0) {
     if (line.length > 0) line.push(text(' '));
-    line.push(text(`(${flags.join(', ')})`));
+    line.push(text('('));
+    if (typeNodes) {
+      line.push(...typeNodes);
+      if (trailingFlags.length > 0) line.push(text(`, ${trailingFlags.join(', ')}`));
+    } else {
+      line.push(text(trailingFlags.join(', ')));
+    }
+    line.push(text(')'));
   }
 
   // The param NAME is the slot discriminator (stable across reorders, unlike an
@@ -776,8 +870,14 @@ export function docletBlocks(
     blocks.push(p(strong(text('Alias:')), text(' '), inlineCode(doclet.alias)));
   }
 
-  // Owning symbol + resolver for the translatable param/return descriptions.
-  const slotCtx: ParamSlotCtx = { slots: options.slots, longname: doclet.longname };
+  // Owning symbol + resolver for the translatable param/return descriptions,
+  // plus the link resolver so param/return/property type names hyperlink to the
+  // symbol they reference.
+  const slotCtx: ParamSlotCtx = {
+    slots: options.slots,
+    longname: doclet.longname,
+    resolveLink: options.resolveLink,
+  };
 
   if (!skip.has('params')) {
     const list = paramsList(doclet.params, slotCtx);
@@ -806,7 +906,8 @@ export function docletBlocks(
 
   // Type only when there's no params/returns (i.e. it's a field/event).
   if (!skip.has('type') && !doclet.params && !doclet.returns && doclet.type) {
-    blocks.push(p(strong(text('Type'))), p(inlineCode(doclet.type.names.join(' | '))));
+    const typeNodes = typeExpressionPhrasing(doclet.type, options.resolveLink, 'code');
+    if (typeNodes) blocks.push(p(strong(text('Type'))), p(...typeNodes));
   }
 
   if (!skip.has('default') && doclet.defaultvalue !== undefined) {

--- a/socket.yml
+++ b/socket.yml
@@ -11,7 +11,8 @@
 # downgraded so the checks focus on genuinely new supply-chain risk. The
 # high-signal alerts (installScripts, telemetry, hasNativeCode, gptMalware,
 # gptDidYouMean / typosquat, httpDependency, unmaintained) are deliberately left
-# ENABLED.
+# ENABLED. shellAccess also stays enabled repo-wide and is disabled only for the
+# one package that legitimately needs it (see packages/aadesh/socket.yml).
 version: 2
 
 issueRules:
@@ -31,10 +32,6 @@ issueRules:
   # dead code in the CJS entry, which resolves via __filename first).
   usesEval: false
   dynamicRequire: false
-
-  # @clean-jsdoc-theme/aadesh is the i18n CLI (`clean-jsdoc`); it spawns the build
-  # pipeline. Expected for a CLI; not present in the theme's render path.
-  shellAccess: false
 
   # The build reads CLEAN_JSDOC_THEME_EXTRACT / cwd to drive extract-vs-build
   # mode. No secrets or credentials are read.

--- a/socket.yml
+++ b/socket.yml
@@ -1,0 +1,51 @@
+# Socket (socket.dev) configuration.
+#
+# Scope: this controls the Socket GitHub App's checks on THIS repo's PRs. It does
+# NOT change what shows on the public socket.dev/npm package page — that comes
+# from the published tarball and is managed via dashboard triage (see NOTE below).
+#
+# clean-jsdoc-theme is a documentation-theme build. The published packages are
+# pure `dist/` output with **no install scripts, no native code, and no
+# telemetry** (verified). The alerts disabled below are inherent to that build
+# (compiled bundles + documented opt-in network features) and are intentionally
+# downgraded so the checks focus on genuinely new supply-chain risk. The
+# high-signal alerts (installScripts, telemetry, hasNativeCode, gptMalware,
+# gptDidYouMean / typosquat, httpDependency, unmaintained) are deliberately left
+# ENABLED.
+version: 2
+
+issueRules:
+  # Compiled output, not hand-obfuscation: dwar inlines the prebuilt Tailwind CSS
+  # as a single string (generated/utility-css.ts) and the islands are esbuild
+  # bundles — both read as "minified"/"obfuscated".
+  minifiedFile: false
+  obfuscatedFile: false
+
+  # Documented, opt-in / lazy UI features only: the fuzzy search index fetch, the
+  # lazy Monaco source viewer (jsdelivr CDN), Google Fonts, brand icons
+  # (simpleicons), and sandboxed embed iframes. No data is exfiltrated.
+  networkAccess: false
+
+  # publish.ts is CJS and dynamic-`import()`s the ESM packages by file:// URL; the
+  # `new Function('import.meta.url')` shim exists only for the .mjs build (it is
+  # dead code in the CJS entry, which resolves via __filename first).
+  usesEval: false
+  dynamicRequire: false
+
+  # @clean-jsdoc-theme/aadesh is the i18n CLI (`clean-jsdoc`); it spawns the build
+  # pipeline. Expected for a CLI; not present in the theme's render path.
+  shellAccess: false
+
+  # The build reads CLEAN_JSDOC_THEME_EXTRACT / cwd to drive extract-vs-build
+  # mode. No secrets or credentials are read.
+  envVars: false
+
+# Local fixtures and the dogfood docs site are never published to npm, so keep
+# them out of the repo scan (they pull in dev-only deps and example content).
+projectIgnorePaths:
+  - 'examples/**'
+  - 'docs-site/**'
+
+# NOTE: to clear the alerts on the *public* socket.dev/npm/package page, mark them
+# as ignored in the Socket org dashboard (Organization → Alerts → triage). The
+# repo socket.yml above does not affect the public package report.

--- a/socket.yml
+++ b/socket.yml
@@ -27,10 +27,10 @@ issueRules:
   # (simpleicons), and sandboxed embed iframes. No data is exfiltrated.
   networkAccess: false
 
-  # publish.ts is CJS and dynamic-`import()`s the ESM packages by file:// URL; the
-  # `new Function('import.meta.url')` shim exists only for the .mjs build (it is
-  # dead code in the CJS entry, which resolves via __filename first).
-  usesEval: false
+  # publish.ts is CJS and dynamic-`import()`s the ESM packages by file:// URL, and
+  # the tsup ESM bundle carries the standard `__require` interop shim. (The old
+  # `new Function('import.meta.url')` eval shim was removed — `usesEval` no longer
+  # needs an exception.)
   dynamicRequire: false
 
   # The build reads CLEAN_JSDOC_THEME_EXTRACT / cwd to drive extract-vs-build


### PR DESCRIPTION
## Problem

In v5, type expressions in the API tables were rendered as **inert code/text** — the v4 behaviour where a type naming a documented symbol (`@param {MyClass}`) linked to that symbol's page was lost. The link registry + resolver existed, but were wired only into `{@link}`/`@see`; the type-rendering path bypassed them entirely (`typeExpressionString`/`typeExpressionInline` just joined `type.names`).

## Fix

Thread the existing registry `resolveLink` into the type-rendering path:

- `linkifyTypeExpression` (in `mdast/doclet.ts`) tokenizes a type expression (e.g. `Array.<MyClass> | null`) and turns each identifier that resolves to a documented symbol into an anchor — **member types resolve to their `slug#anchor`** too — while built-ins (`string`, `Array`) and unresolved names stay inert.
- Applied to every type-bearing slot: **parameters** (incl. constructor params), **properties**, **returns/throws/yields**, the field **`Type:`** line, and the **`@augments`/`@implements`/`@mixes`** relations.
- **Byte-identical fallback**: with no resolver (the localization-extract path) or when nothing resolves, output is unchanged — so the no-locale/extract paths are unaffected.

The TypeDoc bridge inherits this for free (same setu pipeline).

## Tests

5 new cases in `link-resolution.test.ts` cover constructor params, method param/return, the field `Type:`, the `@augments` relation, and that built-ins stay unlinked. Full suite green (442 setu / all package tasks).

## Verified end-to-end

Built the **dwv** docs against this branch:

- `Image` constructor params link — `Geometry` → `/geometry`, `TypedArray` → `/typedarray`; `Array.<string>` stays inert.
- `#member` links work: `getWorker()`'s return type `Worker | undefined` → `` [`Worker`](/global#worker)` | undefined` `` (union splits, only the resolvable token links).
- Links render as real `<a>` anchors in the HTML.

(v5 URLs differ from v4 by design — `/image/` + heading anchors rather than `Image.html#constructor`.)

Partially addresses the v4→v5 regression reported in #333.