### PR TITLE
Resolve local images everywhere + staticFiles + sitemap.xml

### DIFF
--- a/docs-site/docs.hi/guides/working-with-images.md
+++ b/docs-site/docs.hi/guides/working-with-images.md
@@ -1,0 +1,124 @@
+---
+title: Images के साथ काम करना
+group: Guides
+order: 6
+---
+
+# Images के साथ काम करना
+
+अपनी documentation में कहीं से भी एक local image को reference करें — एक docs page,
+एक tutorial, आपका README, या एक JSDoc / TypeScript doc comment — और theme उस file
+को बने हुए साइट में copy कर देता है और link को आपके लिए rewrite कर देता है। output
+में हाथ से file copy करने की ज़रूरत नहीं, किसी absolute URL की ज़रूरत नहीं।
+
+नीचे दिया गया diagram इस साइट के `assets/` folder में एक local SVG है, जिसे एक
+root-relative path से reference किया गया है:
+
+![The clean-jsdoc-theme build pipeline](/assets/build-pipeline.svg)
+
+> [!TIP]
+> यही page इसका जीता-जागता उदाहरण है — इसका source
+> [`docs-site/docs/guides/working-with-images.md`](https://github.com/ankitskvmdam/clean-jsdoc-theme/blob/master/docs-site/docs/guides/working-with-images.md)
+> है।
+
+## यह कहाँ काम करता है
+
+Local image resolution हर उस prose source पर लागू होता है जिसे theme render करता है:
+
+- **Docs pages** (`opts.docs`) — वे Markdown/HTML files जो इस जैसी साइट बनाती हैं।
+- **Tutorials** (`--tutorials`) — JSDoc का tutorial tree।
+- **README** — project का README जो आपका home page बनता है।
+- **API comments** — किसी JSDoc या TypeScript doc comment (एक class / function /
+  method description) में लिखी गई image।
+
+हर मामले में आप एक सामान्य Markdown image (या एक raw `<img>` tag) लिखते हैं और बाकी
+सब theme संभाल लेता है — configure करने के लिए कुछ नहीं है।
+
+## एक path कैसे resolve होता है
+
+आप जो `src` लिखते हैं उसे उस file के सापेक्ष resolve किया जाता है जिसमें वह दिखता है:
+
+| आप जो `src` लिखते हैं | किसके सापेक्ष resolve होता है |
+| --- | --- |
+| एक relative path (`./img/x.svg`, `../img/x.svg`) | source file की अपनी directory |
+| एक root-relative path (`/assets/x.svg`) | आपका project root |
+| एक `http(s)://…` URL या एक `data:` URI | अछूता छोड़ दिया जाता है (external) |
+
+तो एक docs page अपने ही folder के सापेक्ष resolve होता है, एक tutorial tutorials
+directory के सापेक्ष, README project root के सापेक्ष, और एक API comment उस **source
+file के सापेक्ष जिसमें comment रहता है**।
+
+एक resolve हुई image को `_assets/<name>.<hash>.<ext>` पर एक **content-hashed** नाम
+के तहत copy किया जाता है (builds के बीच स्थिर, बदलने पर cache-busting) और reference
+को उस पर point करने के लिए rewrite कर दिया जाता है। एक raw HTML `<img src="…">` को
+बिल्कुल एक Markdown `![](…)` की तरह ही संभाला जाता है।
+
+## JSDoc / TypeScript comment में
+
+API reference images कोई विशेष मामला नहीं हैं — एक doc comment में सीधे एक Markdown
+image लिखें और वह **उस source file के सापेक्ष resolve होती है जिसमें comment रहता
+है**, फिर किसी भी अन्य image की तरह `_assets/` में hash हो जाती है:
+
+```js
+/**
+ * Processes a data stream and emits the running total.
+ *
+ * ![Data flow](../img/data-flow.svg)
+ *
+ * @param {string[]} data - The items to process.
+ * @returns {Promise<number>} The processed count.
+ */
+async function process(data) { /* … */ }
+```
+
+JSDoc का `plugins/markdown` इसे theme के comment देखने से पहले ही एक `<img>` में
+render कर देता है, और TypeDoc के doc comments भी इसी तरह काम करते हैं।
+
+## JSDoc `staticFiles`
+
+JSDoc में static assets के एक folder को ship करने का एक standard option है —
+`templates.default.staticFiles.include` — जहाँ files output root पर पहुँचती हैं और
+आप उन्हें उनके **सादे नाम** (`![diagram](classes-io.png)`) से reference करते हैं,
+आम तौर पर `resources/doc/img` जैसी directory से:
+
+```json5
+// jsdoc.json
+templates: { default: { staticFiles: { include: ["resources/doc/img"] } } }
+```
+
+theme इस convention का पालन करता है: आप वहाँ जितनी भी directories सूचीबद्ध करते
+हैं, हर एक एक **fallback search root** बन जाती है, इसलिए एक सादा (या root-relative)
+image reference resolve होकर ऊपर बताए गए उसी content-hashed `_assets/` pipeline से
+होकर गुज़रता है — आपको मौजूदा comments या tutorials को relative paths में फिर से
+लिखने की ज़रूरत नहीं। उन directories में मौजूद कोई भी **non-image** files (एक
+`.puml` source, एक PDF, …) फिर भी site root पर **verbatim** copy की जाती हैं, जो
+JSDoc के व्यवहार से मेल खाता है; जिस image को pipeline ने पहले ही `_assets/` से
+serve कर दिया है, उसे root पर दोबारा copy नहीं किया जाता।
+
+> [!NOTE]
+> `staticFiles` एक JSDoc option है। TypeDoc के साथ, अपनी images को source के पास
+> या अपने `docs` folder में रखें और उन्हें एक relative या root-relative path से
+> reference करें — वे उसी `_assets/` pipeline से होकर गुज़रती हैं।
+
+## SVGs theme-aware होती हैं
+
+`.svg` files को एक अतिरिक्त कदम मिलता है: उनके markup को `<img>` के ज़रिए load करने
+के बजाय सीधे page में **inline** कर दिया जाता है। इससे एक SVG की अपनी
+`[data-theme="dark"]` styles (या एक `currentColor` fill) in-page theme toggle का
+अनुसरण कर पाती हैं — एक `<img>` से load हुई SVG केवल operating system की color
+scheme देख सकती है, कभी आपकी साइट का toggle नहीं। इस page को light और dark के बीच
+toggle करें: ऊपर दिया गया diagram उसी के साथ अपना रंग बदल लेता है।
+
+## Code उदाहरण सुरक्षित हैं
+
+**उदाहरण के तौर पर** दिखाई गई image syntax — एक inline `code span` या एक fenced
+block के अंदर — बिल्कुल वैसी ही छोड़ दी जाती है जैसी लिखी गई है; केवल prose में
+मौजूद असली images ही copy और rewrite होती हैं। इसीलिए इस page पर हर `![…](…)`
+snippet `_assets/` link में बदलने के बजाय literally render होता है।
+
+## आगे
+
+- [Configuration → How assets are handled](/theme/configuration#how-assets-are-handled)
+  — अंदरूनी asset pipeline, जो logos और custom CSS/JS के साथ साझा है।
+- [Build a guides site](/guides/build-a-guides-site) — वह prose-first workflow
+  जिससे यह साइट बनी है।

--- a/docs-site/docs.hi/theme/configuration.md
+++ b/docs-site/docs.hi/theme/configuration.md
@@ -158,6 +158,40 @@ cleanJsdocTheme: { basePath: "/my-library" } // example.com/my-library/ पर s
 
 </tabs>
 
+### `siteUrl`
+
+आपकी site का सार्वजनिक base URL। सेट होने पर, build output root पर एक
+**`sitemap.xml`** emit करता है — हर page के लिए एक entry (hidden source-viewer
+pages को छोड़कर) — जिसे आप search engines को submit कर सकते हैं या `robots.txt`
+से reference कर सकते हैं। इसके बिना कोई sitemap नहीं बनता।
+
+**अपेक्षित:** एक पूर्ण `http(s)` URL। हर page के URL के लिए केवल इसका **origin**
+इस्तेमाल होता है; deploy sub-path [`basePath`](#basepath) से आता है, इसलिए दोनों
+कभी double-count नहीं होते — एक सादा origin (`https://example.com`) और एक पूरा URL
+जिसका path आपके `basePath` के बराबर हो (`https://example.com/my-library`), दोनों
+एक ही सही `<loc>` entries देते हैं। कोई sitemap न चाहिए तो इसे छोड़ दें (default)।
+
+<tabs group="tool">
+
+<tab label="JSDoc (jsdoc.json)">
+
+```json5
+opts: { siteUrl: "https://example.com", basePath: "/my-library" }
+// → https://example.com/my-library/… URLs वाला sitemap.xml
+```
+
+</tab>
+
+<tab label="TypeDoc (typedoc.json)">
+
+```json5
+cleanJsdocTheme: { siteUrl: "https://example.com", basePath: "/my-library" }
+```
+
+</tab>
+
+</tabs>
+
 ### `favicon`
 
 एक favicon image का path। bridge इसे एक content-hashed `_assets/` asset में copy

--- a/docs-site/docs.ja/guides/working-with-images.md
+++ b/docs-site/docs.ja/guides/working-with-images.md
@@ -1,0 +1,123 @@
+---
+title: 画像を扱う
+group: Guides
+order: 6
+---
+
+# 画像を扱う
+
+documentation のどこからでも local な画像を reference できます — docs page、
+tutorial、README、あるいは JSDoc / TypeScript の doc comment — すると theme がその
+file をビルド後のサイトに copy し、link をあなたの代わりに rewrite します。output
+へ手作業で file を copy する必要はなく、absolute URL も不要です。
+
+下の diagram は、このサイトの `assets/` folder にある local な SVG で、
+root-relative な path で reference しています：
+
+![The clean-jsdoc-theme build pipeline](/assets/build-pipeline.svg)
+
+> [!TIP]
+> この page そのものが実例です — source は
+> [`docs-site/docs/guides/working-with-images.md`](https://github.com/ankitskvmdam/clean-jsdoc-theme/blob/master/docs-site/docs/guides/working-with-images.md)
+> にあります。
+
+## どこで効くか
+
+Local な画像の解決は、theme が render するすべての prose source に適用されます：
+
+- **Docs pages** (`opts.docs`) — このようなサイトを構築する Markdown/HTML の file。
+- **Tutorials** (`--tutorials`) — JSDoc の tutorial tree。
+- **README** — home page になる project の README。
+- **API comments** — JSDoc または TypeScript の doc comment（class / function /
+  method の description）に書いた画像。
+
+どの場合も、普通の Markdown 画像（または raw な `<img>` tag）を書くだけで、残りは
+theme が引き受けます — 設定するものは何もありません。
+
+## path はどう解決されるか
+
+書いた `src` は、それが現れる file を基準に解決されます：
+
+| 書く `src` | 何を基準に解決されるか |
+| --- | --- |
+| relative な path（`./img/x.svg`、`../img/x.svg`） | その source file 自身の directory |
+| root-relative な path（`/assets/x.svg`） | あなたの project root |
+| `http(s)://…` URL または `data:` URI | そのまま（external として残す） |
+
+つまり docs page は自身の folder を基準に、tutorial は tutorials directory を基準
+に、README は project root を基準に、API comment は **その comment があるソース
+file** を基準に解決されます。
+
+解決された画像は `_assets/<name>.<hash>.<ext>` に **content-hashed** な名前で copy
+され（build をまたいで安定し、変更時には cache-busting）、reference はそこを指すよう
+rewrite されます。raw な HTML `<img src="…">` も Markdown の `![](…)` とまったく
+同じように扱われます。
+
+## JSDoc / TypeScript comment の中
+
+API reference の画像も特別扱いではありません — doc comment に直接 Markdown 画像を
+書けば、**その comment があるソース file** を基準に解決され、ほかの画像と同じように
+`_assets/` へ hash されます:
+
+```js
+/**
+ * Processes a data stream and emits the running total.
+ *
+ * ![Data flow](../img/data-flow.svg)
+ *
+ * @param {string[]} data - The items to process.
+ * @returns {Promise<number>} The processed count.
+ */
+async function process(data) { /* … */ }
+```
+
+JSDoc の `plugins/markdown` が theme の見る前に `<img>` へ render し、TypeDoc の
+doc comment も同じように動きます。
+
+## JSDoc `staticFiles`
+
+JSDoc には static asset の folder を配布するための標準オプションがあります —
+`templates.default.staticFiles.include` — これは file を output root に置き、
+**素の名前**（`![diagram](classes-io.png)`）で参照する仕組みで、ふつうは
+`resources/doc/img` のような directory から使います:
+
+```json5
+// jsdoc.json
+templates: { default: { staticFiles: { include: ["resources/doc/img"] } } }
+```
+
+theme はこの慣習を尊重します。そこに列挙した各 directory は **fallback の検索
+ルート**になるので、素の（または root-relative な）画像参照が解決され、上で説明
+した同じ content-hashed `_assets/` pipeline を通ります — 既存の comment や
+tutorial を relative path に書き換える必要はありません。それらの directory にある
+**画像以外**の file（`.puml` の source、PDF など）は、JSDoc の挙動どおり site root
+に **verbatim** で copy されます。pipeline が既に `_assets/` から提供した画像が
+root にもう一度 copy されることはありません。
+
+> [!NOTE]
+> `staticFiles` は JSDoc のオプションです。TypeDoc では画像を source の隣か
+> `docs` folder に置き、relative または root-relative な path で参照してください
+> — 同じ `_assets/` pipeline を通ります。
+
+## SVG は theme に追従する
+
+`.svg` file にはもう一手間あります： markup を `<img>` 経由で読み込むのではなく、
+page に直接 **inline** します。これにより SVG 自身の `[data-theme="dark"]` styles
+（あるいは `currentColor` の塗り）が in-page の theme toggle に追従できます —
+`<img>` で読み込まれた SVG は operating system のカラースキームしか見えず、サイトの
+toggle は見えません。この page を light と dark で切り替えてみてください。上の
+diagram もそれに合わせて色が変わります。
+
+## code 例は安全です
+
+**例として** 示した画像 syntax — inline の `code span` や fenced block の中 — は
+書いたとおりにそのまま残ります。copy されて rewrite されるのは prose 中の実際の
+画像だけです。だからこの page の `![…](…)` の各 snippet は `_assets/` link に
+変わらず、そのまま literal に表示されます。
+
+## 次へ
+
+- [Configuration → How assets are handled](/theme/configuration#how-assets-are-handled)
+  — 内部の asset pipeline。logos や custom CSS/JS と共有しています。
+- [Build a guides site](/guides/build-a-guides-site) — このサイトを構築している
+  prose-first な workflow。

--- a/docs-site/docs.ja/theme/configuration.md
+++ b/docs-site/docs.ja/theme/configuration.md
@@ -159,6 +159,41 @@ cleanJsdocTheme: { basePath: "/my-library" } // example.com/my-library/ で serv
 
 </tabs>
 
+### `siteUrl`
+
+サイトの公開 base URL です。設定すると、build は output root に
+**`sitemap.xml`** を emit します — page ごとに 1 エントリ（hidden な
+source-viewer pages は除外）— で、search engine に submit したり `robots.txt`
+から参照したりできます。未設定なら sitemap は生成されません。
+
+**期待される値:** 絶対 `http(s)` URL。各 page の URL にはその **origin** のみが
+使われ、deploy の sub-path は [`basePath`](#basepath) から来ます。そのため両者が
+二重に数えられることはありません — 素の origin (`https://example.com`) でも、
+path が `basePath` と一致する完全な URL (`https://example.com/my-library`) でも、
+同じ正しい `<loc>` エントリになります。sitemap が不要なら省略してください
+（default）。
+
+<tabs group="tool">
+
+<tab label="JSDoc (jsdoc.json)">
+
+```json5
+opts: { siteUrl: "https://example.com", basePath: "/my-library" }
+// → https://example.com/my-library/… の URL を持つ sitemap.xml
+```
+
+</tab>
+
+<tab label="TypeDoc (typedoc.json)">
+
+```json5
+cleanJsdocTheme: { siteUrl: "https://example.com", basePath: "/my-library" }
+```
+
+</tab>
+
+</tabs>
+
 ### `favicon`
 
 favicon image への path です。bridge はそれを content-hashed な `_assets/` asset に

--- a/docs-site/docs.zh/guides/working-with-images.md
+++ b/docs-site/docs.zh/guides/working-with-images.md
@@ -1,0 +1,115 @@
+---
+title: 使用图片
+group: Guides
+order: 6
+---
+
+# 使用图片
+
+在文档的任何位置 reference 一张本地图片——一个 docs page、一个 tutorial、你的
+README，或一段 JSDoc / TypeScript doc comment——主题就会把该文件 copy 进构建好的
+站点，并替你 rewrite 链接。无需手动把文件 copy 到 output，也无需 absolute URL。
+
+下面这张 diagram 是本站 `assets/` 文件夹中的一个本地 SVG，使用 root-relative 路径
+reference：
+
+![The clean-jsdoc-theme build pipeline](/assets/build-pipeline.svg)
+
+> [!TIP]
+> 这个页面本身就是可运行的示例——它的 source 是
+> [`docs-site/docs/guides/working-with-images.md`](https://github.com/ankitskvmdam/clean-jsdoc-theme/blob/master/docs-site/docs/guides/working-with-images.md)。
+
+## 在哪些地方生效
+
+本地图片解析适用于主题渲染的每一种 prose source：
+
+- **Docs pages**（`opts.docs`）——构建本站这类站点的 Markdown/HTML 文件。
+- **Tutorials**（`--tutorials`）——JSDoc 的 tutorial 树。
+- **README**——成为你首页的项目 README。
+- **API comments**——写在 JSDoc 或 TypeScript doc comment（class / function /
+  method 的 description）里的图片。
+
+每种情况下，你只需写一个普通的 Markdown 图片（或一个 raw `<img>` tag），其余的交给
+主题处理——没有任何需要配置的东西。
+
+## 路径如何解析
+
+你写的 `src` 会相对它所在的文件来解析：
+
+| 你写的 `src` | 相对什么解析 |
+| --- | --- |
+| 相对路径（`./img/x.svg`、`../img/x.svg`） | source 文件自身的目录 |
+| root-relative 路径（`/assets/x.svg`） | 你的 project root |
+| `http(s)://…` URL 或 `data:` URI | 保持原样（external） |
+
+也就是说，docs page 相对它自己的文件夹解析，tutorial 相对 tutorials 目录解析，
+README 相对 project root 解析，而 API comment 相对 **comment 所在的源文件**解析。
+
+解析后的图片会以 **content-hashed** 的名字 copy 到 `_assets/<name>.<hash>.<ext>`
+（跨构建保持稳定，内容变更时自动 cache-busting），并把引用 rewrite 为指向它。raw 的
+HTML `<img src="…">` 与 Markdown 的 `![](…)` 处理方式完全一致。
+
+## 在 JSDoc / TypeScript comment 中
+
+API reference 图片并不是特例——直接在 doc comment 里写一个 Markdown 图片，它会相对
+**comment 所在的源文件**解析，然后像其他图片一样 hash 进 `_assets/`：
+
+```js
+/**
+ * Processes a data stream and emits the running total.
+ *
+ * ![Data flow](../img/data-flow.svg)
+ *
+ * @param {string[]} data - The items to process.
+ * @returns {Promise<number>} The processed count.
+ */
+async function process(data) { /* … */ }
+```
+
+JSDoc 的 `plugins/markdown` 会在主题看到 comment 之前就把它 render 成 `<img>`，
+TypeDoc 的 doc comment 也以同样的方式工作。
+
+## JSDoc `staticFiles`
+
+JSDoc 有一个用于分发静态资源文件夹的标准选项——
+`templates.default.staticFiles.include`——其中文件会落到 output root，你用它们的
+**裸名字**（`![diagram](classes-io.png)`）来引用，通常来自像 `resources/doc/img`
+这样的目录：
+
+```json5
+// jsdoc.json
+templates: { default: { staticFiles: { include: ["resources/doc/img"] } } }
+```
+
+主题会遵循这一约定：你在那里列出的每个目录都会成为一个 **fallback 搜索根**，因此
+一个裸的（或 root-relative 的）图片引用会被解析，并流经上面描述的同一条
+content-hashed `_assets/` pipeline——你无需把现有的 comment 或 tutorial 改写成相对
+路径。这些目录中的任何**非图片**文件（一个 `.puml` source、一个 PDF……）仍会按
+JSDoc 的行为 **verbatim** 复制到站点根目录；pipeline 已经从 `_assets/` 提供过的
+图片，不会再被复制到根目录第二次。
+
+> [!NOTE]
+> `staticFiles` 是一个 JSDoc 选项。使用 TypeDoc 时，把图片放在 source 旁边或你的
+> `docs` 文件夹中，并用相对或 root-relative 路径引用它们——它们会流经同一条
+> `_assets/` pipeline。
+
+## SVG 会跟随主题
+
+`.svg` 文件还多一步：它的 markup 会被直接 **inline** 进页面，而不是通过 `<img>`
+加载。这样 SVG 自身的 `[data-theme="dark"]` 样式（或 `currentColor` 填充）就能跟随
+页面内的 theme toggle——通过 `<img>` 加载的 SVG 只能看到操作系统的配色方案，永远看
+不到你站点的 toggle。把这个页面在 light 与 dark 之间切换试试：上面的 diagram 会随之
+重新着色。
+
+## 代码示例是安全的
+
+**作为示例**展示的图片 syntax——位于 inline `code span` 或 fenced block 中——会原样
+保留；只有 prose 中的真实图片才会被复制和 rewrite。这就是为什么本页的每个
+`![…](…)` 片段都按字面 render，而不会变成 `_assets/` 链接。
+
+## 下一步
+
+- [Configuration → How assets are handled](/theme/configuration#how-assets-are-handled)
+  ——底层的 asset pipeline，与 logos 和 custom CSS/JS 共用。
+- [Build a guides site](/guides/build-a-guides-site)——构建本站所用的 prose-first
+  工作流。

--- a/docs-site/docs.zh/theme/configuration.md
+++ b/docs-site/docs.zh/theme/configuration.md
@@ -155,6 +155,39 @@ cleanJsdocTheme: { basePath: "/my-library" } // served at example.com/my-library
 
 </tabs>
 
+### `siteUrl`
+
+你站点的公开 base URL。设置后，构建会在 output root 生成一个
+**`sitemap.xml`**——每个页面一条记录（不含隐藏的 source-viewer 页面）——你可以
+将它提交给搜索引擎，或在 `robots.txt` 中引用。不设置则不生成 sitemap。
+
+**预期值：** 一个绝对的 `http(s)` URL。每个页面的 URL 只使用它的 **origin**；
+部署子路径来自 [`basePath`](#basepath)，因此两者绝不会重复计入——无论是裸 origin
+(`https://example.com`)，还是 path 恰好等于你 `basePath` 的完整 URL
+(`https://example.com/my-library`)，都会生成相同且正确的 `<loc>` 条目。不需要
+sitemap 时省略它（默认）。
+
+<tabs group="tool">
+
+<tab label="JSDoc (jsdoc.json)">
+
+```json5
+opts: { siteUrl: "https://example.com", basePath: "/my-library" }
+// → 生成包含 https://example.com/my-library/… URL 的 sitemap.xml
+```
+
+</tab>
+
+<tab label="TypeDoc (typedoc.json)">
+
+```json5
+cleanJsdocTheme: { siteUrl: "https://example.com", basePath: "/my-library" }
+```
+
+</tab>
+
+</tabs>
+
 ### `favicon`
 
 一个指向 favicon 图片的路径。桥接器会把它复制为一个带内容哈希的

--- a/docs-site/docs/guides/working-with-images.md
+++ b/docs-site/docs/guides/working-with-images.md
@@ -1,0 +1,122 @@
+---
+title: Working with images
+group: Guides
+order: 6
+---
+
+# Working with images
+
+Reference a local image from anywhere in your documentation — a docs page, a
+tutorial, your README, or a JSDoc / TypeScript doc comment — and the theme copies
+the file into the built site and rewrites the link for you. No copying files into
+the output by hand, no absolute URLs required.
+
+The diagram below is a local SVG in this site's `assets/` folder, referenced with
+a root-relative path:
+
+![The clean-jsdoc-theme build pipeline](/assets/build-pipeline.svg)
+
+> [!TIP]
+> This very page is the worked example — its source is
+> [`docs-site/docs/guides/working-with-images.md`](https://github.com/ankitskvmdam/clean-jsdoc-theme/blob/master/docs-site/docs/guides/working-with-images.md).
+
+## Where it works
+
+Local image resolution applies to every prose source the theme renders:
+
+- **Docs pages** (`opts.docs`) — the Markdown/HTML files that build a site like this one.
+- **Tutorials** (`--tutorials`) — JSDoc's tutorial tree.
+- **README** — the project README that becomes your home page.
+- **API comments** — an image written in a JSDoc or TypeScript doc comment (a
+  class / function / method description).
+
+In every case you write a normal Markdown image (or a raw `<img>` tag) and the
+theme handles the rest — there's nothing to configure.
+
+## How a path is resolved
+
+The `src` you write is resolved against the file it appears in:
+
+| `src` you write | Resolves relative to |
+| --- | --- |
+| a relative path (`./img/x.svg`, `../img/x.svg`) | the source file's own directory |
+| a root-relative path (`/assets/x.svg`) | your project root |
+| an `http(s)://…` URL or a `data:` URI | left untouched (external) |
+
+So a docs page resolves against its own folder, a tutorial against the tutorials
+directory, the README against the project root, and an API comment against the
+**source file the comment lives in**.
+
+A resolved image is copied to `_assets/<name>.<hash>.<ext>` under a
+**content-hashed** name (stable across builds, cache-busting on change) and the
+reference is rewritten to point at it. A raw HTML `<img src="…">` is handled
+exactly like a Markdown `![](…)`.
+
+## In a JSDoc / TypeScript comment
+
+API reference images aren't a special case — write a Markdown image straight into
+a doc comment and it resolves against **the source file the comment lives in**,
+then gets hashed into `_assets/` like any other:
+
+```js
+/**
+ * Processes a data stream and emits the running total.
+ *
+ * ![Data flow](../img/data-flow.svg)
+ *
+ * @param {string[]} data - The items to process.
+ * @returns {Promise<number>} The processed count.
+ */
+async function process(data) { /* … */ }
+```
+
+JSDoc's `plugins/markdown` renders that to an `<img>` before the theme ever sees
+the comment, and TypeDoc doc comments work the same way.
+
+## JSDoc `staticFiles`
+
+JSDoc has a standard option for shipping a folder of static assets —
+`templates.default.staticFiles.include` — where the files land at the output root
+and you reference them by their **bare name** (`![diagram](classes-io.png)`),
+typically from a directory like `resources/doc/img`:
+
+```json5
+// jsdoc.json
+templates: { default: { staticFiles: { include: ["resources/doc/img"] } } }
+```
+
+The theme honors that convention: every directory you list there becomes a
+**fallback search root**, so a bare (or root-relative) image reference resolves
+and flows through the same content-hashed `_assets/` pipeline described above —
+you don't have to rewrite existing comments or tutorials to relative paths. Any
+**non-image** files in those directories (a `.puml` source, a PDF, …) are still
+copied **verbatim** to the site root, matching JSDoc's behavior; an image the
+pipeline already served from `_assets/` isn't copied to the root a second time.
+
+> [!NOTE]
+> `staticFiles` is a JSDoc option. With TypeDoc, keep your images beside the
+> source or in your `docs` folder and reference them with a relative or
+> root-relative path — they flow through the same `_assets/` pipeline.
+
+## SVGs are theme-aware
+
+`.svg` files get one extra step: their markup is **inlined** into the page rather
+than loaded through an `<img>`. That lets an SVG's own `[data-theme="dark"]`
+styles (or a `currentColor` fill) follow the in-page theme toggle — an
+`<img>`-loaded SVG can only ever see the operating system's color scheme, never
+your site's toggle. Flip this page between light and dark: the diagram above
+recolors right along with it.
+
+## Code examples are safe
+
+Image syntax shown **as an example** — inside an inline `code span` or a fenced
+block — is left exactly as written; only real images in prose are copied and
+rewritten. That's why every `![…](…)` snippet on this page renders literally
+instead of turning into an `_assets/` link.
+
+## Next
+
+- [Configuration → How assets are handled](/theme/configuration#how-assets-are-handled)
+  — the underlying asset pipeline, shared with logos and custom CSS/JS.
+- [Build a guides site](/guides/build-a-guides-site) — the prose-first workflow
+  this site is built with.

--- a/docs-site/docs/theme/configuration.md
+++ b/docs-site/docs/theme/configuration.md
@@ -157,6 +157,40 @@ cleanJsdocTheme: { basePath: "/my-library" } // served at example.com/my-library
 
 </tabs>
 
+### `siteUrl`
+
+Your site's public base URL. When set, the build emits a **`sitemap.xml`** at the
+output root — one entry per page (hidden source-viewer pages are excluded) — which
+you can submit to search engines or reference from `robots.txt`. Without it, no
+sitemap is generated.
+
+**Expected:** an absolute `http(s)` URL. Only its **origin** is used for each
+page's URL; the deploy sub-path comes from [`basePath`](#basepath), so the two
+never double-count — a bare origin (`https://example.com`) and a full URL whose
+path equals your `basePath` (`https://example.com/my-library`) both produce the
+same, correct `<loc>` entries. Omit it (the default) for no sitemap.
+
+<tabs group="tool">
+
+<tab label="JSDoc (jsdoc.json)">
+
+```json5
+opts: { siteUrl: "https://example.com", basePath: "/my-library" }
+// → sitemap.xml with https://example.com/my-library/… URLs
+```
+
+</tab>
+
+<tab label="TypeDoc (typedoc.json)">
+
+```json5
+cleanJsdocTheme: { siteUrl: "https://example.com", basePath: "/my-library" }
+```
+
+</tab>
+
+</tabs>
+
 ### `favicon`
 
 A path to a favicon image. The bridge copies it to a content-hashed
@@ -808,13 +842,14 @@ templates: { default: { sourceLinkToComment: true } }
 ### How assets are handled
 
 You don't configure this, but it's worth knowing how local files referenced from
-your docs and README are processed. Any image you link with a relative or
-root-relative path — `![diagram](./assets/flow.svg)` — is copied into the site's
-`_assets/` directory under a **content-hashed** name (e.g.
-`_assets/flow.3de65053.svg`) and the reference is rewritten to point at it. The
-hash is derived from the file's bytes, so an unchanged file keeps a stable,
+your docs, tutorials, README, and **API doc comments** are processed. Any image
+you link with a relative or root-relative path — `![diagram](./assets/flow.svg)` —
+is copied into the site's `_assets/` directory under a **content-hashed** name
+(e.g. `_assets/flow.3de65053.svg`) and the reference is rewritten to point at it.
+The hash is derived from the file's bytes, so an unchanged file keeps a stable,
 cacheable URL across builds and a changed one cache-busts automatically. External
-(`https://…`) and `data:` URLs are left untouched.
+(`https://…`) and `data:` URLs are left untouched. (See
+[Working with images](/guides/working-with-images) for the full guide.)
 
 `.svg` files get one extra step: their markup is **inlined** directly into the
 page rather than loaded through an `<img>`. That lets an SVG's own
@@ -824,6 +859,18 @@ SVG can only see the operating system's color scheme, never your site's toggle.
 Logos ([`siteName`](#sitename)) and
 [`customCssFile` / `customJsFile`](#customcssfile-and-customjsfile) ride the same
 content-hashed `_assets/` pipeline.
+
+#### JSDoc `staticFiles`
+
+If you use JSDoc's standard `templates.default.staticFiles.include` to ship a
+folder of images (the convention where files land at the output root and you
+reference them by bare name, e.g. `![diagram](classes-io.png)`), the theme
+honors it: those directories become **fallback search roots**, so a bare or
+root-relative reference resolves and flows through the same content-hashed
+`_assets/` pipeline above — no need to rewrite your comments to relative paths.
+Any **non-image** files in those directories are still copied **verbatim** to the
+site root, matching JSDoc's behavior. (A file the image pipeline already served
+from `_assets/` isn't copied to the root a second time.)
 
 ## Localization
 

--- a/docs-site/jsdoc.json
+++ b/docs-site/jsdoc.json
@@ -9,6 +9,7 @@
   "opts": {
     "encoding": "utf8",
     "basePath": "/clean-jsdoc-theme",
+    "siteUrl": "https://ankitskvmdam.github.io/clean-jsdoc-theme",
     "destination": "dist/clean-jsdoc-theme",
     "recurse": true,
     "template": "./node_modules/clean-jsdoc-theme/dist",

--- a/docs-site/jsdoc.json
+++ b/docs-site/jsdoc.json
@@ -9,7 +9,7 @@
   "opts": {
     "encoding": "utf8",
     "basePath": "/clean-jsdoc-theme",
-    "siteUrl": "https://ankitskvmdam.github.io/clean-jsdoc-theme",
+    "siteUrl": "https://ankdev.me/clean-jsdoc-theme/",
     "destination": "dist/clean-jsdoc-theme",
     "recurse": true,
     "template": "./node_modules/clean-jsdoc-theme/dist",

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -498,6 +498,10 @@ dwar/src/
 ├── theme-script.ts       # pre-hydration <script>: theme + font-size/line-spacing
 ├── heading-anchors.ts    # inline <script>: delegated heading clicks → hash +
 │                         #   copy link; sets data-copied 3s for the check-icon swap
+├── sitemap.ts            # buildSitemapXml(siteUrl, basePath, slugs) — pure; one
+│                         #   <loc> per non-hidden page (origin from siteUrl,
+│                         #   sub-path from basePath). render() emits sitemap.xml
+│                         #   when opts.siteUrl is set
 ├── pagefind.ts           # runPagefindAgainstDir(destination)  — the only fs touch
 styles/
 └── tailwind.css          # Tailwind v4 input: @theme tokens, tw-animate-css, base
@@ -537,7 +541,12 @@ section), and a **prev/next pager** (rang's `PageNav`) below the body: dwar
 flattens `manifest.nav` into linear reading order (skipping external/menu
 entries), maps each non-hidden page to its neighbors, and renders the two cards
 (title + ≤100-char description). Gated by `ThemeConfig.pageNav` (on by default),
-never on source pages. The full-text Pagefind bundle is a separate post-write step.
+never on source pages. When `RenderOptions.siteUrl` is set, dwar also emits a
+**`sitemap.xml`** at the output root — one `<loc>` per non-hidden page (the same
+set as `RenderResult.search`, so hidden source-viewer pages are excluded), using
+`siteUrl`'s origin + `theme.basePath` + slug; an unparseable URL emits nothing
+rather than a broken sitemap. The full-text Pagefind bundle is a separate
+post-write step.
 
 **Custom CSS/JS.** `ThemeConfig` carries optional `customCss`/`customJs` (inline
 strings) and `customCssLinks`/`customJsLinks` (asset hrefs). Inline strings are
@@ -609,11 +618,32 @@ clean-jsdoc-theme/src/
 │                         #   *.html → DocInput[] w/ POSIX rel path + raw content; the
 │                         #   only place the docs tree is read) and threads docs +
 │                         #   opts.docGroups + opts.defaultDocGroup → setu.
-│                         #   resolveDocImages then routes every local image those docs
-│                         #   reference through the content-hashed _assets/ pipeline
-│                         #   (copy + rewrite src), and additionally collects each .svg's
+│                         #   A shared image pipeline (createImageCollector +
+│                         #   rewriteImageRefs) routes every LOCAL image — Markdown
+│                         #   ![](src) AND raw <img src> — referenced from docs
+│                         #   (resolveDocImages), tutorials (resolveTutorialImages,
+│                         #   base = tutorials dir), the README (base = cwd), and
+│                         #   JSDoc-comment prose (resolveDocletImages: mutates
+│                         #   doclets IN PLACE — salty hands out live refs — base =
+│                         #   each doclet's meta.path) through the content-hashed
+│                         #   _assets/ pipeline (copy + rewrite src to /_assets/…,
+│                         #   deduped across all sources), and collects each .svg's
 │                         #   markup into render()'s inlineSvgs map so it's inlined
-│                         #   (theme-toggle-aware) rather than <img>-ed.
+│                         #   (theme-toggle-aware) rather than <img>-ed. Image
+│                         #   syntax inside code spans / fenced blocks / <pre>/<code>
+│                         #   is skipped (CODE_REGION_RE), so literal ![](…) shown as
+│                         #   example syntax stays verbatim.
+│                         #   JSDoc templates.default.staticFiles is honored
+│                         #   (readStaticFilesConfig + collectStaticFiles): matched
+│                         #   files are copied VERBATIM to the output root (JSDoc
+│                         #   parity, for non-image assets), AND the include dirs
+│                         #   become fallback search roots for the image collector
+│                         #   — so a bare ![](classes-io.png) whose file lives in a
+│                         #   staticFiles dir still resolves + hashes (v5 pages are
+│                         #   nested, so the ref is rewritten, not just copied). A
+│                         #   verbatim copy is skipped when the image pipeline
+│                         #   already consumed it (served from _assets/), and when it
+│                         #   would clobber a generated path / reserved dir (warned).
 │                         #   Holds defaultTheme (OKLCH palette).
 └── write-output-files.ts # mkdir -p + writeFile loop (forward-slash → OS path)
 ```
@@ -645,12 +675,21 @@ typedoc/src/
 │                           #   fonts + normalized sectionOrder/menu/clubSidebarItems/
 │                           #   copyPage/pageNav/aiPrompt through, and walks the
 │                           #   `docs` dir (docs.ts) → docs + docGroups/
-│                           #   defaultDocGroup + inlineSvgs. Prints the utils
-│                           #   formatBuildReport (node:zlib gzip sizer — allowed here,
-│                           #   it's the bridge, not utils). Holds defaultTheme.
-├── docs.ts                 # prose-docs front-end (copied from the JSDoc bridge):
-│                           #   collectDocs (walk dir → DocInput[]) + resolveDocImages
-│                           #   (local images → content-hashed _assets/ + inline SVGs).
+│                           #   defaultDocGroup + inlineSvgs. Routes README +
+│                           #   symbol-comment images through the same _assets/
+│                           #   pipeline via one shared collector (resolveDocletImages
+│                           #   mutates doclets IN PLACE before generateSite; README
+│                           #   base = cwd), merging files (deduped) + inlineSvgs.
+│                           #   Prints the utils formatBuildReport (node:zlib gzip
+│                           #   sizer — allowed here, it's the bridge, not utils).
+│                           #   Holds defaultTheme.
+├── docs.ts                 # prose-docs front-end + shared local-image pipeline
+│                           #   (copied from the JSDoc bridge): collectDocs (walk dir
+│                           #   → DocInput[]) + createImageCollector/rewriteImageRefs
+│                           #   (Markdown ![](src) AND raw <img src> → content-hashed
+│                           #   _assets/ + inline SVGs; hrefForServed threads basePath)
+│                           #   + resolveDocImages (docs) + resolveDocletImages
+│                           #   (comment HTML, base = each symbol's meta.path).
 ├── reflection-to-doclets.ts# THE adapter: ProjectReflection → flat TDoclet[].
 │                           #   Class/Interface/Function/Method/Property/Variable/
 │                           #   Accessor/Enum(+isEnum)/EnumMember/TypeAlias(typedef)/

--- a/examples/basic/README.md
+++ b/examples/basic/README.md
@@ -1,5 +1,7 @@
 # examples/basic
 
+![Data flow from Source through DataProcessor to Output](./img/data-flow.svg)
+
 End-to-end fixture for `clean-jsdoc-theme` v5. A [`src/`](./src) of
 JSDoc-annotated source files — exercising modules, namespaces, classes,
 interfaces, mixins, typedefs, constants/enums, and globals, plus tutorials and a

--- a/examples/basic/img/data-flow.puml
+++ b/examples/basic/img/data-flow.puml
@@ -1,0 +1,7 @@
+@startuml
+' Source for data-flow.svg. Declared via templates.default.staticFiles.include,
+' so it is copied verbatim to the built site's root (a non-image static file the
+' image pipeline does not touch).
+[Source] --> [DataProcessor]
+[DataProcessor] --> [Output]
+@enduml

--- a/examples/basic/img/data-flow.svg
+++ b/examples/basic/img/data-flow.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 520 130" role="img" aria-label="Data flow: Source to DataProcessor to Output">
+  <style>
+    .box { fill: none; stroke: currentColor; stroke-width: 1.5; }
+    .label { fill: currentColor; font: 600 14px ui-sans-serif, system-ui, sans-serif; }
+    .arrow { stroke: currentColor; stroke-width: 1.5; fill: none; marker-end: url(#arrowhead); }
+  </style>
+  <defs>
+    <marker id="arrowhead" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto">
+      <path d="M0,0 L6,3 L0,6 Z" fill="currentColor" />
+    </marker>
+  </defs>
+  <rect class="box" x="8" y="45" width="120" height="40" rx="6" />
+  <text class="label" x="68" y="70" text-anchor="middle">Source</text>
+  <line class="arrow" x1="132" y1="65" x2="195" y2="65" />
+  <rect class="box" x="200" y="45" width="150" height="40" rx="6" />
+  <text class="label" x="275" y="70" text-anchor="middle">DataProcessor</text>
+  <line class="arrow" x1="354" y1="65" x2="417" y2="65" />
+  <rect class="box" x="392" y="45" width="120" height="40" rx="6" />
+  <text class="label" x="452" y="70" text-anchor="middle">Output</text>
+</svg>

--- a/examples/basic/jsdoc.json
+++ b/examples/basic/jsdoc.json
@@ -6,10 +6,18 @@
     "include": ["./src", "./README.md"]
   },
   "plugins": ["plugins/markdown"],
+  "templates": {
+    "default": {
+      "staticFiles": {
+        "include": ["./img"]
+      }
+    }
+  },
   "opts": {
     "encoding": "utf8",
     "destination": "dist",
     "recurse": true,
+    "siteUrl": "https://clean-jsdoc-theme.example.com",
     "template": "./node_modules/clean-jsdoc-theme/dist",
     "readme": "./README.md",
     "tutorials": "./tutorials",

--- a/examples/basic/src/DataProcessor.js
+++ b/examples/basic/src/DataProcessor.js
@@ -3,6 +3,14 @@
  * @summary Advanced data processing suite.
  * @description This class extends the {@link BaseEntity} to provide
  * async processing and event-driven updates.
+ *
+ * A local image referenced from a JSDoc comment is copied into the built site
+ * and its path rewritten, just like in tutorials and docs. The diagram below
+ * lives in `img/data-flow.svg` (a sibling of `src/`), so it is referenced with
+ * a `../img/` relative path:
+ *
+ * ![Data flow from Source through DataProcessor to Output](../img/data-flow.svg)
+ *
  * @tutorial processing-guide
  * @category Core/Processing order=1
  * @author Ankit Kumar <mailto:ankit@example.com>

--- a/examples/basic/tutorials/tutorials.json
+++ b/examples/basic/tutorials/tutorials.json
@@ -15,6 +15,9 @@
   "markdown-examples": {
     "title": "Markdown Examples"
   },
+  "working-with-images": {
+    "title": "Working with Images"
+  },
   "how-jsdoc-works": {
     "title": "How JSDoc Works"
   }

--- a/examples/basic/tutorials/working-with-images.md
+++ b/examples/basic/tutorials/working-with-images.md
@@ -1,0 +1,45 @@
+# Working with Images
+
+Tutorials can reference **local image files** the same way docs pages do. Use a
+plain relative Markdown image and the theme copies the file into the built
+site's `_assets/` directory (content-hashed for caching) and rewrites the
+reference for you — no manual copying, no absolute URLs needed.
+
+The image below lives in `img/data-flow.svg`, a sibling of this `tutorials/`
+directory, so it is referenced with a `../img/` relative path:
+
+![Data flow from Source through DataProcessor to Output](../img/data-flow.svg)
+
+Because it is an SVG, the theme inlines it so its colors follow the light/dark
+toggle (it draws with `currentColor`).
+
+## How resolution works
+
+The image `src` you write is resolved against the tutorials directory, exactly
+as a docs image is resolved against its own folder:
+
+| `src` you write | Resolves to |
+| --- | --- |
+| a relative path (`../img/...`) | relative to the tutorials directory |
+| a root-relative path (`/img/...`) | the project root |
+| an `http(s):` URL or `data:` URI | left untouched (external) |
+
+Raw HTML image tags work too — the tag just above this section is written as
+plain HTML rather than Markdown:
+
+<img src="../img/data-flow.svg" alt="Data flow diagram" />
+
+External URLs and `data:` URIs are always left exactly as written.
+
+## JSDoc `staticFiles`
+
+If you already keep images in a directory declared via JSDoc's
+`templates.default.staticFiles.include` (this example declares `./img`), you can
+reference them by their **bare output name** — the theme searches those
+directories too and routes the image through the same `_assets/` pipeline:
+
+![data-flow](data-flow.svg)
+
+Any non-image files in those directories (this example ships a `data-flow.puml`
+source alongside the SVG) are copied **verbatim** to the site root, matching
+JSDoc's behavior.

--- a/examples/typedoc-basic/img/event-flow.svg
+++ b/examples/typedoc-basic/img/event-flow.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 520 130" role="img" aria-label="Event flow: emit to EventEmitter to Listeners">
+  <style>
+    .box { fill: none; stroke: currentColor; stroke-width: 1.5; }
+    .label { fill: currentColor; font: 600 14px ui-sans-serif, system-ui, sans-serif; }
+    .arrow { stroke: currentColor; stroke-width: 1.5; fill: none; marker-end: url(#ev-arrow); }
+  </style>
+  <defs>
+    <marker id="ev-arrow" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto">
+      <path d="M0,0 L6,3 L0,6 Z" fill="currentColor" />
+    </marker>
+  </defs>
+  <rect class="box" x="8" y="45" width="120" height="40" rx="6" />
+  <text class="label" x="68" y="70" text-anchor="middle">emit()</text>
+  <line class="arrow" x1="132" y1="65" x2="195" y2="65" />
+  <rect class="box" x="200" y="45" width="150" height="40" rx="6" />
+  <text class="label" x="275" y="70" text-anchor="middle">EventEmitter</text>
+  <line class="arrow" x1="354" y1="65" x2="417" y2="65" />
+  <rect class="box" x="392" y="45" width="120" height="40" rx="6" />
+  <text class="label" x="452" y="70" text-anchor="middle">Listeners</text>
+</svg>

--- a/examples/typedoc-basic/src/services/EventEmitter.ts
+++ b/examples/typedoc-basic/src/services/EventEmitter.ts
@@ -75,6 +75,13 @@ interface ListenerEntry<T> {
  * - Async event handlers
  * - Wildcard event listening
  *
+ * A local image referenced from a TypeScript doc comment is copied into the
+ * built site and its path rewritten, just like in `docs` pages and the README.
+ * The diagram below lives in `img/event-flow.svg`, referenced from this source
+ * file (`src/services/`) with a `../../img/` relative path:
+ *
+ * ![Event flow from emit() through EventEmitter to Listeners](../../img/event-flow.svg)
+ *
  * @typeParam TEvents - Event map type defining event names and data types
  *
  * @example

--- a/examples/typedoc-basic/typedoc.json
+++ b/examples/typedoc-basic/typedoc.json
@@ -7,6 +7,7 @@
   "outputs": [{ "name": "clean-jsdoc-theme", "path": "dist" }],
   "cleanJsdocTheme": {
     "siteName": "typedoc-basic",
+    "siteUrl": "https://typedoc-basic.example.com",
     "docs": "docs",
     "docGroups": ["Guides"],
     "clubSidebarItems": false,

--- a/packages/clean-jsdoc-theme/src/__tests__/publish.test.ts
+++ b/packages/clean-jsdoc-theme/src/__tests__/publish.test.ts
@@ -5,6 +5,9 @@ import { afterAll, beforeAll, describe, it, expect, vi } from 'vitest';
 import {
   collectDocs,
   resolveDocImages,
+  resolveTutorialImages,
+  resolveDocletImages,
+  createImageCollector,
   overlayDocs,
   computeRelPaths,
   hasMarkdownPlugin,
@@ -492,7 +495,172 @@ describe('resolveDocImages', () => {
     vi.restoreAllMocks();
   });
 
+  it('rewrites raw HTML <img> srcs too (both quote styles)', async () => {
+    const docs = [
+      {
+        path: 'overview',
+        type: 'html' as const,
+        content: '<p><img src="./assets/diagram.svg" alt="d"></p>\n<img src=\'./assets/diagram.svg\' />',
+      },
+    ];
+    const { docs: out, files } = await resolveDocImages(docs, dir);
+    // Same image referenced twice → copied once, both srcs rewritten.
+    expect(files).toHaveLength(1);
+    const m = out[0].content.match(/\/_assets\/diagram\.[0-9a-f]{8}\.svg/g);
+    expect(m).toHaveLength(2);
+    expect(out[0].content).not.toContain('./assets/diagram.svg');
+  });
+
+  it('leaves image syntax inside code spans and fenced blocks untouched', async () => {
+    const docs = [
+      {
+        path: 'overview',
+        type: 'markdown' as const,
+        // The real image (top) resolves; the two shown AS EXAMPLES (inline code +
+        // fenced block) must be left verbatim, even though the file exists.
+        content:
+          '![real](./assets/diagram.svg)\n\n' +
+          'Write `![alt](./assets/diagram.svg)` to embed it.\n\n' +
+          '```md\n![alt](./assets/diagram.svg)\n```\n',
+      },
+    ];
+    const { docs: out, files } = await resolveDocImages(docs, dir);
+    // Only the real one was copied (deduped to a single asset).
+    expect(files).toHaveLength(1);
+    const rewritten = out[0].content.match(/\/_assets\/diagram\.[0-9a-f]{8}\.svg/g) ?? [];
+    expect(rewritten).toHaveLength(1); // just the top reference
+    // The code-span and fenced occurrences keep the literal source path.
+    expect(out[0].content).toContain('`![alt](./assets/diagram.svg)`');
+    expect(out[0].content).toContain('```md\n![alt](./assets/diagram.svg)\n```');
+  });
+
+  it('does not warn for an unreadable image shown only as code-example syntax', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const docs = [
+      { path: 'x', type: 'markdown' as const, content: 'Example: `![d](./nope.png)`\n' },
+    ];
+    const { files } = await resolveDocImages(docs, dir);
+    expect(files).toHaveLength(0);
+    expect(warn).not.toHaveBeenCalled(); // never attempted to read it
+    warn.mockRestore();
+  });
+
   it('returns docs unchanged when there are none', async () => {
     expect(await resolveDocImages([], dir)).toEqual({ docs: [], files: [], inlineSvgs: {} });
+  });
+});
+
+describe('resolveTutorialImages', () => {
+  let dir: string;
+
+  beforeAll(async () => {
+    // Tutorials live in `<dir>/tutorials`; the image is a sibling `<dir>/img`,
+    // referenced from a tutorial as `../img/x.svg` (the bug-report pattern).
+    dir = await mkdtemp(join(tmpdir(), 'cjt-tut-images-'));
+    await mkdir(join(dir, 'img'), { recursive: true });
+    await writeFile(join(dir, 'img', 'flow.svg'), '<svg/>', 'utf8');
+  });
+
+  afterAll(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it('copies + rewrites a relative tutorial image and recurses into children', async () => {
+    const tree = [
+      {
+        name: 'guide',
+        title: 'Guide',
+        type: 'markdown' as const,
+        content: '# Guide\n\n![Flow](../img/flow.svg)\n',
+        children: [
+          {
+            name: 'sub',
+            title: 'Sub',
+            type: 'html' as const,
+            content: '<img src="../img/flow.svg" alt="f">',
+            children: [],
+          },
+        ],
+      },
+    ];
+    const collector = createImageCollector();
+    const tutorialsDir = join(dir, 'tutorials');
+    const out = await resolveTutorialImages(tree, tutorialsDir, collector);
+    // Copied once (shared by parent + child via the collector cache).
+    expect(collector.files).toHaveLength(1);
+    expect(collector.files[0].path).toMatch(/^_assets\/flow\.[0-9a-f]{8}\.svg$/);
+    expect(out[0].content).toMatch(/!\[Flow\]\(\/_assets\/flow\.[0-9a-f]{8}\.svg\)/);
+    expect(out[0].children![0].content).toMatch(/src="\/_assets\/flow\.[0-9a-f]{8}\.svg"/);
+    // The SVG is also queued for inlining, keyed by the rewritten src.
+    expect(collector.inlineSvgs['/' + collector.files[0].path]).toContain('<svg style=');
+    // Input tree is left untouched (a new tree is returned).
+    expect(tree[0].content).toContain('../img/flow.svg');
+  });
+
+  it('leaves external srcs untouched', async () => {
+    const tree = [
+      { name: 'g', title: 'G', type: 'markdown' as const, content: '![x](https://e.com/i.png)', children: [] },
+    ];
+    const collector = createImageCollector();
+    const out = await resolveTutorialImages(tree, join(dir, 'tutorials'), collector);
+    expect(collector.files).toHaveLength(0);
+    expect(out[0].content).toContain('https://e.com/i.png');
+  });
+});
+
+describe('resolveDocletImages', () => {
+  let dir: string;
+
+  beforeAll(async () => {
+    dir = await mkdtemp(join(tmpdir(), 'cjt-doclet-images-'));
+    await mkdir(join(dir, 'src'), { recursive: true });
+    await mkdir(join(dir, 'img'), { recursive: true });
+    await writeFile(join(dir, 'img', 'diagram.png'), 'PNGBYTES', 'utf8');
+  });
+
+  afterAll(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  /** A minimal salty-like collection: `data().get()` returns live references. */
+  const salty = (items: unknown[]) => {
+    const fn = () => ({ get: () => items });
+    return fn as unknown;
+  };
+
+  it('rewrites <img> in a doclet description relative to its source file, in place', async () => {
+    // JSDoc's markdown plugin has already rendered `![d](../img/diagram.png)` to
+    // HTML by publish time; the src is relative to the comment's source file.
+    const doclet = {
+      longname: 'Foo',
+      description: '<p>Hello</p><img src="../img/diagram.png" alt="d">',
+      params: [{ name: 'x', description: '<img src="../img/diagram.png" alt="p">' }],
+      meta: { path: join(dir, 'src'), filename: 'foo.js' },
+    };
+    const collector = createImageCollector();
+    await resolveDocletImages(salty([doclet]), collector);
+    // Copied once (description + param share the image via the cache).
+    expect(collector.files).toHaveLength(1);
+    expect(collector.files[0].path).toMatch(/^_assets\/diagram\.[0-9a-f]{8}\.png$/);
+    // Mutated in place: setu will read these rewritten fields.
+    expect(doclet.description).toMatch(/src="\/_assets\/diagram\.[0-9a-f]{8}\.png"/);
+    expect(doclet.params[0].description).toMatch(/src="\/_assets\/diagram\.[0-9a-f]{8}\.png"/);
+  });
+
+  it('skips meta/comment/examples and doclets without meta.path', async () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const noMeta = { longname: 'Bar', description: '<img src="../img/diagram.png">' };
+    const codeOnly = {
+      longname: 'Baz',
+      examples: ['<img src="../img/diagram.png">'],
+      comment: '/** ![d](../img/diagram.png) */',
+      meta: { path: join(dir, 'src'), filename: 'baz.js' },
+    };
+    const collector = createImageCollector();
+    await resolveDocletImages(salty([noMeta, codeOnly]), collector);
+    expect(collector.files).toHaveLength(0); // nothing resolvable was scanned
+    expect(noMeta.description).toContain('../img/diagram.png'); // untouched (no meta.path)
+    expect(codeOnly.examples[0]).toContain('../img/diagram.png'); // examples skipped
+    vi.restoreAllMocks();
   });
 });

--- a/packages/clean-jsdoc-theme/src/__tests__/static-files.test.ts
+++ b/packages/clean-jsdoc-theme/src/__tests__/static-files.test.ts
@@ -1,0 +1,243 @@
+import { mkdtemp, mkdir, writeFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, beforeAll, describe, it, expect, vi } from 'vitest';
+import {
+  createImageCollector,
+  resolveTutorialImages,
+  normalizeStaticFilesConfig,
+  staticFileOutputName,
+  staticFileIncluded,
+  collectStaticFiles,
+} from '../publish';
+
+describe('normalizeStaticFilesConfig', () => {
+  it('accepts a string or array include; trims and drops empties', () => {
+    expect(normalizeStaticFilesConfig({ include: 'resources/img' })).toEqual({
+      include: ['resources/img'],
+      exclude: [],
+    });
+    expect(
+      normalizeStaticFilesConfig({ include: ['  a ', '', 'b', 7], exclude: 'b/skip' })
+    ).toEqual({ include: ['a', 'b'], exclude: ['b/skip'] });
+  });
+
+  it('keeps include/exclude patterns when non-empty strings', () => {
+    expect(
+      normalizeStaticFilesConfig({
+        include: ['img'],
+        includePattern: '\\.png$',
+        excludePattern: '\\.puml$',
+      })
+    ).toEqual({
+      include: ['img'],
+      exclude: [],
+      includePattern: '\\.png$',
+      excludePattern: '\\.puml$',
+    });
+  });
+
+  it('returns undefined when there is nothing usable to include', () => {
+    expect(normalizeStaticFilesConfig(undefined)).toBeUndefined();
+    expect(normalizeStaticFilesConfig({})).toBeUndefined();
+    expect(normalizeStaticFilesConfig({ include: [] })).toBeUndefined();
+    expect(normalizeStaticFilesConfig({ include: [123] })).toBeUndefined();
+    expect(normalizeStaticFilesConfig('img')).toBeUndefined();
+    expect(normalizeStaticFilesConfig(['img'])).toBeUndefined();
+  });
+});
+
+describe('staticFileOutputName', () => {
+  it('strips the include-dir prefix (contents land at the output root)', () => {
+    expect(staticFileOutputName('/proj/resources/img/x.png', '/proj/resources/img')).toBe('x.png');
+    expect(staticFileOutputName('/proj/resources/img/sub/y.png', '/proj/resources/img')).toBe(
+      'sub/y.png'
+    );
+  });
+
+  it('uses the basename for a single-file include', () => {
+    expect(staticFileOutputName('/proj/resources/img/x.png', '/proj/resources/img/x.png')).toBe(
+      'x.png'
+    );
+  });
+
+  it('is Windows-separator and case tolerant', () => {
+    expect(staticFileOutputName('C:\\proj\\IMG\\a\\b.png', 'C:\\proj\\img')).toBe('a/b.png');
+    expect(staticFileOutputName('C:/proj/img/', 'C:/proj/img')).toBe('img'); // trailing slash → basename
+  });
+});
+
+describe('staticFileIncluded', () => {
+  const cfg = (extra: Record<string, unknown> = {}) => ({ include: ['x'], exclude: [], ...extra });
+
+  it('honors includePattern / excludePattern against the POSIX abs path', () => {
+    expect(staticFileIncluded('/proj/img/a.png', cfg({ includePattern: '\\.png$' }))).toBe(true);
+    expect(staticFileIncluded('/proj/img/a.puml', cfg({ includePattern: '\\.png$' }))).toBe(false);
+    expect(staticFileIncluded('/proj/img/a.puml', cfg({ excludePattern: '\\.puml$' }))).toBe(false);
+    expect(staticFileIncluded('/proj/img/a.png', cfg({ excludePattern: '\\.puml$' }))).toBe(true);
+  });
+
+  it('excludes a file equal to, or nested under, an excluded path', () => {
+    const c = cfg({ exclude: ['/proj/img/private'] });
+    expect(staticFileIncluded('/proj/img/private', c)).toBe(false);
+    expect(staticFileIncluded('/proj/img/private/secret.png', c)).toBe(false);
+    expect(staticFileIncluded('/proj/img/public.png', c)).toBe(true);
+  });
+
+  it('fails open on a malformed pattern (treats it as no filter)', () => {
+    expect(staticFileIncluded('/proj/img/a.png', cfg({ includePattern: '(' }))).toBe(true);
+  });
+});
+
+describe('collectStaticFiles', () => {
+  let dir: string;
+
+  beforeAll(async () => {
+    dir = await mkdtemp(join(tmpdir(), 'cjt-staticfiles-'));
+    await mkdir(join(dir, 'img', 'sub'), { recursive: true });
+    await writeFile(join(dir, 'img', 'a.png'), 'A', 'utf8');
+    await writeFile(join(dir, 'img', 'diagram.svg'), '<svg/>', 'utf8');
+    await writeFile(join(dir, 'img', 'a.puml'), 'PUML', 'utf8');
+    await writeFile(join(dir, 'img', 'sub', 'b.png'), 'B', 'utf8');
+    await mkdir(join(dir, 'img', '.hidden'), { recursive: true });
+    await writeFile(join(dir, 'img', '.hidden', 'h.png'), 'H', 'utf8');
+    await writeFile(join(dir, 'single.png'), 'S', 'utf8');
+  });
+
+  afterAll(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it('walks a dir → entries mapped to the output root (prefix stripped), plus the search dir', async () => {
+    const { files, searchDirs } = await collectStaticFiles({
+      include: [join(dir, 'img')],
+      exclude: [],
+    });
+    // Contents land at the output ROOT; subdirs preserved; dot-dirs skipped; sorted.
+    expect(files.map((f) => f.outputPath)).toEqual(['a.png', 'a.puml', 'diagram.svg', 'sub/b.png']);
+    expect(files.find((f) => f.outputPath === 'a.png')!.contents.toString()).toBe('A');
+    expect(searchDirs).toEqual([join(dir, 'img')]);
+    expect(files.every((f) => f.absSource.length > 0)).toBe(true);
+  });
+
+  it('a single-file include lands at root; the search dir is its parent', async () => {
+    const { files, searchDirs } = await collectStaticFiles({
+      include: [join(dir, 'single.png')],
+      exclude: [],
+    });
+    expect(files.map((f) => f.outputPath)).toEqual(['single.png']);
+    expect(searchDirs).toEqual([dir]);
+  });
+
+  it('honors excludePattern (drop .puml)', async () => {
+    const { files } = await collectStaticFiles({
+      include: [join(dir, 'img')],
+      exclude: [],
+      excludePattern: '\\.puml$',
+    });
+    expect(files.map((f) => f.outputPath)).toEqual(['a.png', 'diagram.svg', 'sub/b.png']);
+  });
+
+  it('warns and skips a missing include (never throws)', async () => {
+    const warn = vi.fn();
+    const { files, searchDirs } = await collectStaticFiles(
+      { include: [join(dir, 'does-not-exist')], exclude: [] },
+      warn
+    );
+    expect(files).toEqual([]);
+    expect(searchDirs).toEqual([]);
+    expect(warn).toHaveBeenCalledOnce();
+  });
+});
+
+describe('image collector — staticFiles fallback resolution (B2)', () => {
+  let dir: string;
+
+  beforeAll(async () => {
+    // Mirror dwv: images in `<dir>/img`, referenced from a doc in `<dir>/tutorials`
+    // by a BARE name that resolves only via the staticFiles search root.
+    dir = await mkdtemp(join(tmpdir(), 'cjt-b2-'));
+    await mkdir(join(dir, 'img'), { recursive: true });
+    await mkdir(join(dir, 'tutorials'), { recursive: true });
+    await writeFile(join(dir, 'img', 'classes-io.png'), 'IO', 'utf8');
+    await writeFile(join(dir, 'img', 'flow.svg'), '<svg/>', 'utf8');
+  });
+
+  afterAll(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it('resolves a bare name via a staticFiles dir, hashes it, records consumed', async () => {
+    const collector = createImageCollector([join(dir, 'img')]);
+    // baseDir = tutorials dir; `classes-io.png` is NOT there, so the fallback
+    // search dir (img) is what makes it resolve.
+    const href = await collector.resolve('classes-io.png', join(dir, 'tutorials'));
+    expect(href).toMatch(/^\/_assets\/classes-io\.[0-9a-f]{8}\.png$/);
+    expect(collector.files).toHaveLength(1);
+    expect(collector.consumed.has(join(dir, 'img', 'classes-io.png'))).toBe(true);
+  });
+
+  it('resolves a /-rooted name via a staticFiles dir too, and queues the SVG for inlining', async () => {
+    const collector = createImageCollector([join(dir, 'img')]);
+    const href = await collector.resolve('/flow.svg', join(dir, 'tutorials'));
+    expect(href).toMatch(/^\/_assets\/flow\.[0-9a-f]{8}\.svg$/);
+    expect(collector.inlineSvgs[href!]).toContain('<svg style=');
+  });
+
+  it('prefers a co-located file over a same-named staticFile', async () => {
+    await writeFile(join(dir, 'tutorials', 'classes-io.png'), 'LOCAL', 'utf8');
+    const collector = createImageCollector([join(dir, 'img')]);
+    await collector.resolve('classes-io.png', join(dir, 'tutorials'));
+    expect(collector.consumed.has(join(dir, 'tutorials', 'classes-io.png'))).toBe(true);
+    expect(collector.consumed.has(join(dir, 'img', 'classes-io.png'))).toBe(false);
+    await rm(join(dir, 'tutorials', 'classes-io.png'), { force: true });
+  });
+
+  it('warns once and returns null when nothing resolves anywhere', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const collector = createImageCollector([join(dir, 'img')]);
+    expect(await collector.resolve('missing.png', join(dir, 'tutorials'))).toBeNull();
+    expect(await collector.resolve('missing.png', join(dir, 'tutorials'))).toBeNull();
+    expect(warn).toHaveBeenCalledTimes(1); // warned-once, keyed by src
+    expect(collector.files).toHaveLength(0);
+    warn.mockRestore();
+  });
+
+  it('with no staticDirs configured, there is no fallback (unchanged behavior)', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const collector = createImageCollector(); // no static dirs
+    expect(await collector.resolve('classes-io.png', join(dir, 'tutorials'))).toBeNull();
+    warn.mockRestore();
+  });
+});
+
+describe('resolveTutorialImages — staticFiles dwv scenario (bare ref)', () => {
+  let dir: string;
+
+  beforeAll(async () => {
+    dir = await mkdtemp(join(tmpdir(), 'cjt-tut-static-'));
+    await mkdir(join(dir, 'img'), { recursive: true });
+    await mkdir(join(dir, 'tutorials'), { recursive: true });
+    await writeFile(join(dir, 'img', 'classes-io.png'), 'IO', 'utf8');
+  });
+
+  afterAll(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it('rewrites a bare `![](classes-io.png)` tutorial ref via the staticFiles dir', async () => {
+    const tree = [
+      {
+        name: 'data-load',
+        title: 'Data Load',
+        type: 'markdown' as const,
+        content: '# Load\n\n![classes-io](classes-io.png)\n',
+        children: [],
+      },
+    ];
+    const collector = createImageCollector([join(dir, 'img')]);
+    const out = await resolveTutorialImages(tree, join(dir, 'tutorials'), collector);
+    expect(out[0].content).toMatch(/!\[classes-io\]\(\/_assets\/classes-io\.[0-9a-f]{8}\.png\)/);
+    expect(collector.consumed.has(join(dir, 'img', 'classes-io.png'))).toBe(true);
+  });
+});

--- a/packages/clean-jsdoc-theme/src/publish.ts
+++ b/packages/clean-jsdoc-theme/src/publish.ts
@@ -3,7 +3,7 @@
 // JSDoc 4 → setu → dwar bridge. `publish(taffyData, opts, tutorials)` is the
 // entry JSDoc invokes; everything below orchestrates the four phase packages.
 
-import { mkdir, readFile, readdir, rm, writeFile } from 'node:fs/promises';
+import { mkdir, readFile, readdir, rm, stat, writeFile } from 'node:fs/promises';
 import { readFileSync } from 'node:fs';
 import { createHash } from 'node:crypto';
 import { basename, dirname, extname, join as joinPath, resolve as resolvePath } from 'node:path';
@@ -308,6 +308,14 @@ interface JSDocOpts {
    */
   footer?: unknown;
   /**
+   * Site public base URL (`jsdoc.json` `"opts": { "siteUrl": "https://example.com" }`).
+   * When set, the build emits a `sitemap.xml` at the output root listing every
+   * non-hidden page's canonical URL. Only the URL's origin is used — the deploy
+   * sub-path comes from `basePath` — so a bare origin or a full URL whose path
+   * equals `basePath` both work. Omit it for no sitemap.
+   */
+  siteUrl?: unknown;
+  /**
    * Favicon (`jsdoc.json` `"opts": { "favicon": "./icon.svg" }`). A path to an
    * image file (`.svg`/`.png`/`.ico`/…), relative to the working dir. The bridge
    * copies it to a content-hashed `_assets/` asset and emits a `<link rel="icon">`
@@ -375,7 +383,20 @@ interface JSDocOpts {
    *    in the destination instead of emptying it before each build.
    */
   templates?: {
-    default?: { outputSourceFiles?: unknown; sourceLinkToComment?: unknown; cleanOutputDir?: unknown };
+    default?: {
+      outputSourceFiles?: unknown;
+      sourceLinkToComment?: unknown;
+      cleanOutputDir?: unknown;
+      /**
+       * JSDoc's standard static-file passthrough
+       * (`templates.default.staticFiles`): `{ include, exclude, includePattern,
+       * excludePattern }`. Files matched by `include` are copied verbatim into
+       * the output (an include dir's contents land at the output root, JSDoc's
+       * mapping) AND their dirs become fallback search roots for image
+       * resolution, so a bare/relative reference to a static image resolves.
+       */
+      staticFiles?: unknown;
+    };
   };
   [key: string]: unknown;
 }
@@ -1296,87 +1317,538 @@ export async function collectDocs(dir: string): Promise<DocInput[]> {
 const DOC_IMAGE_RE = /(!\[[^\]]*\]\()([^)\s]+)((?:\s+"[^"]*")?\))/g;
 
 /**
- * Resolve the local images a doc references and route them through the same
- * content-hashed `_assets/` pipeline the logo and custom files use. For each
- * `![alt](src)` whose `src` points to a file on disk, the file is copied to
- * `_assets/<base>.<hash><ext>` (cache-busted, deduped across docs) and the `src`
- * is rewritten to the root-relative `/_assets/<base>.<hash><ext>` (rang's
- * `MdxImg` adds the base path, like it does for links). A `src` is resolved
- * relative to the project root when it starts with `/`, else relative to the
- * doc's own directory; absolute (`http(s):`, `data:`), `#`-anchor, and
- * unreadable srcs are left untouched (the last with a warning). Returns the docs
- * with rewritten content plus the asset files to write. The bridge is the I/O
- * layer here, so setu/dwar only ever see the final `_assets/` paths.
+ * HTML image: captures the `<img …src=` prefix (through the opening quote), the
+ * quote char, the src value, and the closing quote (a backreference to the
+ * opener). JSDoc's `plugins/markdown` renders a comment's `![alt](src)` to
+ * `<img src="…" alt="…">`, and prose can embed raw `<img>`; this matches both
+ * quote styles wherever `src` sits in the tag.
+ */
+const HTML_IMAGE_RE = /(<img\b[^>]*?\bsrc\s*=\s*(["']))([^"']*)(\2)/gi;
+
+/**
+ * A reusable local-image asset pipeline shared by every prose source (docs,
+ * tutorials, README, doclet comments). `resolve(src, baseDir)` copies a local
+ * image to `_assets/<base>.<hash><ext>` (content-hashed → cache-busted, deduped
+ * across all sources via the shared caches) and returns the root-relative
+ * `/_assets/…` href. It accumulates each copied file on `files`, each SVG's
+ * markup on `inlineSvgs` (keyed by the rewritten href, so the renderer can inline
+ * it — its `[data-theme]` styles then track the toggle), and the absolute source
+ * path of every copied image on `consumed` (so the static-file passthrough can
+ * skip re-copying an image it already served from `_assets/`).
+ *
+ * Resolution tries, in order: the doc-relative path (or project root for a
+ * `/`-rooted src), then — for the JSDoc `staticFiles` convention — each
+ * `staticDirs` root joined with the reference's output-relative name. So a bare
+ * `![x](classes-io.png)` whose file lives in a declared `staticFiles` dir still
+ * resolves and is hashed. External (`http(s):`, `data:`), `#`-anchor, and
+ * fully-unresolvable srcs yield `null` (the last warned once) so callers leave
+ * them untouched.
+ */
+export interface ImageCollector {
+  resolve(rawSrc: string, baseDir: string): Promise<string | null>;
+  readonly files: OutputFile[];
+  readonly inlineSvgs: Record<string, string>;
+  readonly consumed: Set<string>;
+}
+
+export function createImageCollector(staticDirs: readonly string[] = []): ImageCollector {
+  const files: OutputFile[] = [];
+  const inlineSvgs: Record<string, string> = {};
+  const consumed = new Set<string>();
+  const seenServed = new Set<string>();
+  // abs path → rewritten src (root-relative `/_assets/…`), or null if unreadable.
+  const cache = new Map<string, string | null>();
+  const warnedMisses = new Set<string>();
+
+  const resolve = async (rawSrc: string, baseDir: string): Promise<string | null> => {
+    const src = rawSrc.trim();
+    if (!src || isServableUrl(src) || src.startsWith('#') || src.startsWith('data:')) return null;
+    // Candidate absolute paths in priority order: the doc-relative / project-root
+    // location first, then each staticFiles dir joined with the output-relative
+    // name (leading slash stripped) as a fallback.
+    const primary = src.startsWith('/') ? resolvePath(src.slice(1)) : resolvePath(baseDir, src);
+    const candidates = [primary];
+    if (staticDirs.length > 0) {
+      const outName = src.replace(/^\/+/, '');
+      if (outName) for (const dir of staticDirs) candidates.push(resolvePath(dir, outName));
+    }
+
+    for (const abs of candidates) {
+      const cached = cache.get(abs);
+      if (cached !== undefined) {
+        if (cached) return cached; // already copied
+        continue; // known miss — try the next candidate
+      }
+      let bytes: Buffer;
+      try {
+        bytes = await readFile(abs);
+      } catch {
+        cache.set(abs, null);
+        continue;
+      }
+      const ext = extname(abs);
+      const served = `_assets/${basename(abs, ext) || 'asset'}.${contentHash(bytes)}${ext}`;
+      if (!seenServed.has(served)) {
+        seenServed.add(served);
+        files.push({ path: served, contents: bytes });
+      }
+      const href = '/' + served;
+      // SVGs are ALSO inlined: the renderer drops the markup into the page so its
+      // `[data-theme="dark"]` styles track the theme toggle (an `<img>`-loaded SVG
+      // only sees the OS color scheme). A responsive sizing style is injected onto
+      // the `<svg>` root; the `_assets/` copy still backs the companion `.md` link.
+      if (ext.toLowerCase() === '.svg') {
+        inlineSvgs[href] = bytes
+          .toString('utf8')
+          .replace(/<svg\b/, '<svg style="max-width:100%;height:auto;display:block"');
+      }
+      cache.set(abs, href);
+      consumed.add(abs);
+      return href;
+    }
+
+    if (!warnedMisses.has(src)) {
+      warnedMisses.add(src);
+      console.warn(
+        `clean-jsdoc-theme: could not read image '${src}' (looked in: ${candidates.join(', ')}); leaving it as-is.`
+      );
+    }
+    return null;
+  };
+
+  return { resolve, files, inlineSvgs, consumed };
+}
+
+/**
+ * Rewrite the local image references in `content` to their content-hashed
+ * `/_assets/…` paths, routing each through `collector`. Handles BOTH Markdown
+ * `![alt](src)` and raw HTML `<img src="…">` (JSDoc renders comment/tutorial
+ * images to the latter), so prose in either form is covered. Relative srcs
+ * resolve against `baseDir`, `/`-rooted srcs against the project root, and
+ * external/`data:`/anchor srcs are left untouched. Returns the original string
+ * unchanged when nothing was rewritten.
+ */
+/**
+ * Char ranges of Markdown/HTML **code** regions — fenced blocks (` ``` `/`~~~`),
+ * HTML `<pre>`/`<code>`, and inline backtick spans. Image references inside these
+ * are literal example syntax an author is *documenting*, not real images, so the
+ * rewriter skips them (no spurious copy/rewrite, no "could not read" warning).
+ * Order matters: the multi-line block forms come before the inline span so a
+ * fence isn't chopped at its first inner backtick.
+ */
+const CODE_REGION_RE =
+  /```[\s\S]*?```|~~~[\s\S]*?~~~|<pre[\s\S]*?<\/pre>|<code[^>]*>[\s\S]*?<\/code>|`[^`\n]+`/gi;
+
+/** Collect the [start, end) char ranges of code regions in `content`. */
+function codeRanges(content: string): Array<[number, number]> {
+  const ranges: Array<[number, number]> = [];
+  for (const m of content.matchAll(CODE_REGION_RE)) {
+    if (m.index !== undefined) ranges.push([m.index, m.index + m[0].length]);
+  }
+  return ranges;
+}
+
+/** Whether char offset `idx` falls inside any of the (sorted-ish) code ranges. */
+function indexInCode(idx: number, ranges: ReadonlyArray<[number, number]>): boolean {
+  for (const [s, e] of ranges) if (idx >= s && idx < e) return true;
+  return false;
+}
+
+async function rewriteImageRefs(
+  content: string,
+  baseDir: string,
+  collector: ImageCollector
+): Promise<string> {
+  if (!content) return content;
+  const ranges = codeRanges(content);
+  const map = new Map<string, string>();
+  const collect = async (re: RegExp, srcGroup: number): Promise<void> => {
+    for (const m of content.matchAll(re)) {
+      if (m.index !== undefined && indexInCode(m.index, ranges)) continue; // example syntax
+      const src = m[srcGroup];
+      if (map.has(src)) continue;
+      const href = await collector.resolve(src, baseDir);
+      if (href) map.set(src, href);
+    }
+  };
+  await collect(DOC_IMAGE_RE, 2);
+  await collect(HTML_IMAGE_RE, 3);
+  if (map.size === 0) return content;
+  return content
+    .replace(DOC_IMAGE_RE, (full, pre, src, post, offset: number) =>
+      !indexInCode(offset, ranges) && map.has(src) ? `${pre}${map.get(src)}${post}` : full
+    )
+    .replace(HTML_IMAGE_RE, (full, pre, _quote, src, close, offset: number) =>
+      !indexInCode(offset, ranges) && map.has(src) ? `${pre}${map.get(src)}${close}` : full
+    );
+}
+
+/**
+ * Resolve the local images a doc references and route them through the shared
+ * content-hashed `_assets/` pipeline (see {@link createImageCollector}). Each
+ * `![alt](src)` / `<img src>` whose `src` points to a file on disk is copied and
+ * its `src` rewritten to the root-relative `/_assets/<base>.<hash><ext>` (rang's
+ * `MdxImg` adds the base path, like it does for links), resolved relative to the
+ * project root when it starts with `/`, else relative to the doc's own directory.
+ * Returns the docs with rewritten content plus the asset files to write. The
+ * bridge is the I/O layer here, so setu/dwar only ever see the final `_assets/`
+ * paths.
  */
 export async function resolveDocImages(
   docs: DocInput[],
-  docsDir: string
+  docsDir: string,
+  collector: ImageCollector = createImageCollector()
 ): Promise<{ docs: DocInput[]; files: OutputFile[]; inlineSvgs: Record<string, string> }> {
-  if (docs.length === 0) return { docs, files: [], inlineSvgs: {} };
+  if (docs.length === 0) return { docs, files: collector.files, inlineSvgs: collector.inlineSvgs };
   const root = resolvePath(docsDir);
-  const files: OutputFile[] = [];
-  const seenServed = new Set<string>();
-  // Inline-SVG markup keyed by the rewritten src, so the renderer can inline the
-  // SVG (→ its `[data-theme]` styles follow the toggle) rather than `<img>` it.
-  const inlineSvgs: Record<string, string> = {};
-  // abs path → rewritten src (root-relative `/_assets/…`), or null if unreadable.
-  const cache = new Map<string, string | null>();
-
-  const resolveOne = async (rawSrc: string, docDir: string): Promise<string | null> => {
-    const src = rawSrc.trim();
-    if (!src || isServableUrl(src) || src.startsWith('#') || src.startsWith('data:')) return null;
-    const abs = src.startsWith('/') ? resolvePath(src.slice(1)) : resolvePath(docDir, src);
-    if (cache.has(abs)) return cache.get(abs) ?? null;
-    let bytes: Buffer;
-    try {
-      bytes = await readFile(abs);
-    } catch {
-      console.warn(
-        `clean-jsdoc-theme: could not read doc image '${src}' (resolved '${abs}'); leaving it as-is.`
-      );
-      cache.set(abs, null);
-      return null;
-    }
-    const ext = extname(abs);
-    const served = `_assets/${basename(abs, ext) || 'asset'}.${contentHash(bytes)}${ext}`;
-    if (!seenServed.has(served)) {
-      seenServed.add(served);
-      files.push({ path: served, contents: bytes });
-    }
-    const href = '/' + served;
-    // SVGs are ALSO inlined: the renderer drops the markup into the page so its
-    // `[data-theme="dark"]` styles track the theme toggle (an `<img>`-loaded SVG
-    // only sees the OS color scheme). A responsive sizing style is injected onto
-    // the `<svg>` root; the `_assets/` copy still backs the companion `.md` link.
-    if (ext.toLowerCase() === '.svg') {
-      inlineSvgs[href] = bytes
-        .toString('utf8')
-        .replace(/<svg\b/, '<svg style="max-width:100%;height:auto;display:block"');
-    }
-    cache.set(abs, href);
-    return href;
-  };
-
   const out: DocInput[] = [];
   for (const doc of docs) {
     const docDir = dirname(resolvePath(root, doc.path));
-    const map = new Map<string, string>();
-    for (const m of doc.content.matchAll(DOC_IMAGE_RE)) {
-      const src = m[2];
-      if (map.has(src)) continue;
-      const href = await resolveOne(src, docDir);
-      if (href) map.set(src, href);
+    const content = await rewriteImageRefs(doc.content, docDir, collector);
+    out.push(content === doc.content ? doc : { ...doc, content });
+  }
+  return { docs: out, files: collector.files, inlineSvgs: collector.inlineSvgs };
+}
+
+/**
+ * Resolve the local images referenced by tutorial content, routing them through
+ * the shared `collector` (the same content-hashed `_assets/` pipeline as docs).
+ * JSDoc reads every tutorial from a single directory, so each tutorial's relative
+ * srcs (`![x](../img/x.png)`, `<img src>`) resolve against `tutorialsDir`. Walks
+ * the resolved tree (sub-tutorials included), rewriting each node's content —
+ * Markdown or HTML; the tree shape is preserved. Returns a new tree (the input is
+ * left untouched). Exported for testing.
+ */
+export async function resolveTutorialImages(
+  tree: TutorialInput[],
+  tutorialsDir: string,
+  collector: ImageCollector
+): Promise<TutorialInput[]> {
+  const base = resolvePath(tutorialsDir);
+  const walk = async (node: TutorialInput): Promise<TutorialInput> => {
+    const content = await rewriteImageRefs(node.content, base, collector);
+    const children: TutorialInput[] = [];
+    for (const child of node.children ?? []) children.push(await walk(child));
+    return { ...node, content, children };
+  };
+  const out: TutorialInput[] = [];
+  for (const node of tree) out.push(await walk(node));
+  return out;
+}
+
+/**
+ * Doclet keys whose string values are raw source/code/meta, NOT rendered prose —
+ * never scanned for images (a stray `<img`/`![` there must not be rewritten).
+ */
+const DOCLET_IMAGE_SKIP_KEYS = new Set([
+  'meta',
+  'comment',
+  'examples',
+  'tags',
+  '___id',
+  '___s',
+]);
+
+/**
+ * Recursively rewrite the `<img>`/`![]()` image srcs in every prose string
+ * reachable from a doclet object, resolving against `baseDir`. Only strings that
+ * actually carry an image marker (`<img` or `![`) are touched — a cheap guard so
+ * names/identifiers/code are never scanned — and raw/code keys
+ * ({@link DOCLET_IMAGE_SKIP_KEYS}) are skipped entirely. Recurses into nested
+ * objects/arrays (e.g. `params[].description`). Mutates `node` in place.
+ */
+async function rewriteDocletStrings(
+  node: Record<string, unknown>,
+  baseDir: string,
+  collector: ImageCollector
+): Promise<void> {
+  for (const [key, value] of Object.entries(node)) {
+    if (DOCLET_IMAGE_SKIP_KEYS.has(key)) continue;
+    if (typeof value === 'string') {
+      if (value.includes('<img') || value.includes('![')) {
+        const rewritten = await rewriteImageRefs(value, baseDir, collector);
+        if (rewritten !== value) node[key] = rewritten;
+      }
+    } else if (Array.isArray(value)) {
+      for (let i = 0; i < value.length; i++) {
+        const item = value[i];
+        if (typeof item === 'string') {
+          if (item.includes('<img') || item.includes('![')) {
+            const rewritten = await rewriteImageRefs(item, baseDir, collector);
+            if (rewritten !== item) value[i] = rewritten;
+          }
+        } else if (item && typeof item === 'object') {
+          await rewriteDocletStrings(item as Record<string, unknown>, baseDir, collector);
+        }
+      }
+    } else if (value && typeof value === 'object') {
+      await rewriteDocletStrings(value as Record<string, unknown>, baseDir, collector);
     }
-    if (map.size === 0) {
-      out.push(doc);
+  }
+}
+
+/**
+ * Resolve the local images referenced inside JSDoc-comment prose (doclet
+ * descriptions, `@classdesc`, nested `@param`/`@property`/`@returns`
+ * descriptions, …) and route them through the shared `collector`. JSDoc's
+ * `plugins/markdown` has already turned a comment's `![alt](../img/x.png)` into
+ * an HTML `<img src="../img/x.png">` by the time `publish` runs, so each src is
+ * resolved **relative to that doclet's own source file** (`meta.path` — the
+ * directory of the file the comment lives in). Doclets are mutated IN PLACE:
+ * salty's `get()` hands out live object references, so the rewrite is visible
+ * when setu later reads the same collection. Resilient — a non-collection `data`
+ * or unreadable image is skipped (the latter warned), never fatal.
+ */
+export async function resolveDocletImages(
+  data: unknown,
+  collector: ImageCollector
+): Promise<void> {
+  if (typeof data !== 'function') return;
+  let doclets: unknown[] = [];
+  try {
+    doclets = (data as (q: unknown) => { get(): unknown[] })({}).get();
+  } catch {
+    try {
+      doclets = (data as () => { get(): unknown[] })().get();
+    } catch {
+      return;
+    }
+  }
+  if (!Array.isArray(doclets)) return;
+
+  for (const d of doclets) {
+    if (!d || typeof d !== 'object') continue;
+    const meta = (d as { meta?: { path?: unknown } }).meta;
+    // Without the source file's directory there's no base to resolve a relative
+    // src against, so skip (synthetic/global doclets often carry no meta.path).
+    if (!meta || typeof meta.path !== 'string' || meta.path.length === 0) continue;
+    await rewriteDocletStrings(d as Record<string, unknown>, meta.path, collector);
+  }
+}
+
+// ─── JSDoc `templates.default.staticFiles` passthrough ──────────────────────
+//
+// JSDoc's default template copies arbitrary files into the output via
+// `templates.default.staticFiles` (an include dir's CONTENTS land at the output
+// root). The theme honors that contract: matched files are copied verbatim
+// (covering non-image assets and references the image pipeline doesn't scan),
+// and the include dirs additionally become fallback search roots so a bare image
+// reference like `![x](classes-io.png)` — which only worked in stock JSDoc
+// because the file was copied to the flat output root — resolves through the
+// content-hashed `_assets/` pipeline here (v5 pages are nested, so the reference
+// also has to be rewritten, not just the file copied).
+
+/** Normalized `templates.default.staticFiles` config. */
+export interface StaticFilesConfig {
+  /** Resolved-as-given include paths (dirs or files), trimmed, non-empty. */
+  include: string[];
+  /** Paths to exclude (a file equal to, or under, an excluded dir is dropped). */
+  exclude: string[];
+  /** Regex (source string) a file's POSIX abs path must match to be included. */
+  includePattern?: string;
+  /** Regex (source string) that drops a file when its POSIX abs path matches. */
+  excludePattern?: string;
+}
+
+/**
+ * Normalize a raw `staticFiles` block into a {@link StaticFilesConfig}, or
+ * `undefined` when there's nothing to include. `include`/`exclude` accept a
+ * string or string[]; patterns are kept as source strings (compiled later, so a
+ * bad pattern fails open rather than throwing). Pure + exported for testing.
+ */
+export function normalizeStaticFilesConfig(raw: unknown): StaticFilesConfig | undefined {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return undefined;
+  const o = raw as Record<string, unknown>;
+  const toStrArr = (v: unknown): string[] =>
+    (Array.isArray(v) ? v : typeof v === 'string' ? [v] : [])
+      .filter((s): s is string => typeof s === 'string' && s.trim().length > 0)
+      .map((s) => s.trim());
+  const include = toStrArr(o.include);
+  if (include.length === 0) return undefined;
+  const includePattern =
+    typeof o.includePattern === 'string' && o.includePattern.trim().length > 0
+      ? o.includePattern
+      : undefined;
+  const excludePattern =
+    typeof o.excludePattern === 'string' && o.excludePattern.trim().length > 0
+      ? o.excludePattern
+      : undefined;
+  return {
+    include,
+    exclude: toStrArr(o.exclude),
+    ...(includePattern ? { includePattern } : {}),
+    ...(excludePattern ? { excludePattern } : {}),
+  };
+}
+
+/**
+ * Read `templates.default.staticFiles` from JSDoc's canonical `jsdoc/env` conf
+ * (the only place the root-level `templates` block lives at runtime), falling
+ * back to a nested `opts.templates.default.staticFiles`. Mirrors the probe order
+ * of {@link outputSourceFilesEnabled}. Returns `undefined` when unset/unusable.
+ */
+export function readStaticFilesConfig(opts: JSDocOpts): StaticFilesConfig | undefined {
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const env = require('jsdoc/env') as {
+      conf?: { templates?: { default?: { staticFiles?: unknown } } };
+    };
+    const fromEnv = normalizeStaticFilesConfig(env?.conf?.templates?.default?.staticFiles);
+    if (fromEnv) return fromEnv;
+  } catch {
+    // `jsdoc/env` isn't resolvable (e.g. unit tests) — fall back to opts.
+  }
+  return normalizeStaticFilesConfig(opts?.templates?.default?.staticFiles);
+}
+
+/**
+ * Output-relative path (POSIX) for a static file under an include root: strip the
+ * resolved-root prefix so `<root>/img/sub/x.png` under root `<root>/img` →
+ * `sub/x.png` (JSDoc maps an include dir's contents to the output ROOT). When the
+ * include was a single FILE (`absFile === includeRootAbs`), the output name is its
+ * basename. Windows-aware: separators are normalized and the prefix match is
+ * case-insensitive (NTFS). Pure + exported for testing.
+ */
+export function staticFileOutputName(absFile: string, includeRootAbs: string): string {
+  const norm = (p: string): string => p.replace(/\\/g, '/').replace(/\/+$/, '');
+  const f = norm(absFile);
+  const root = norm(includeRootAbs);
+  const baseOf = (p: string): string => p.slice(p.lastIndexOf('/') + 1);
+  if (f === root) return baseOf(f); // single-file include
+  const prefix = root + '/';
+  return f.toLowerCase().startsWith(prefix.toLowerCase()) ? f.slice(prefix.length) : baseOf(f);
+}
+
+/**
+ * Whether a static file passes a config's filter — `includePattern` (must match),
+ * `excludePattern` (must not match), and `exclude` (file equal to, or nested
+ * under, an excluded path is dropped). Patterns are tested against the file's
+ * POSIX-normalized absolute path; a malformed pattern fails open (ignored). Pure
+ * + exported for testing.
+ */
+export function staticFileIncluded(absFile: string, config: StaticFilesConfig): boolean {
+  const norm = (p: string): string => resolvePath(p).replace(/\\/g, '/');
+  const fn = norm(absFile);
+  if (config.includePattern) {
+    try {
+      if (!new RegExp(config.includePattern).test(fn)) return false;
+    } catch {
+      /* bad pattern → ignore (fail open) */
+    }
+  }
+  if (config.excludePattern) {
+    try {
+      if (new RegExp(config.excludePattern).test(fn)) return false;
+    } catch {
+      /* bad pattern → ignore */
+    }
+  }
+  for (const ex of config.exclude) {
+    const exAbs = norm(ex);
+    if (fn === exAbs || fn.toLowerCase().startsWith(exAbs.toLowerCase() + '/')) return false;
+  }
+  return true;
+}
+
+/** Directory names skipped while walking a staticFiles tree (build/vcs noise). */
+const STATIC_DIR_SKIP = new Set(['node_modules', '.git', '.svn', '.hg']);
+
+/** One verbatim static-file copy entry. */
+export interface StaticFileEntry {
+  /** Output-relative POSIX path (where it lands under the destination). */
+  outputPath: string;
+  /** Absolute source path (matched against the image collector's `consumed`). */
+  absSource: string;
+  contents: Buffer;
+}
+
+/**
+ * Collect the files matched by a {@link StaticFilesConfig}: walk each include
+ * path (a directory recursively, or a single file), apply
+ * {@link staticFileIncluded}, and read each match. Returns the verbatim copy
+ * entries (output path = include-root-stripped, JSDoc's "contents → output root"
+ * mapping) plus the resolved `searchDirs` the image resolver uses as fallback
+ * roots (an include dir as-is; a file include's parent dir). Resilient: a missing
+ * include path / unreadable file is warned + skipped, never fatal. Exported for
+ * testing.
+ */
+export async function collectStaticFiles(
+  config: StaticFilesConfig,
+  warn: (message: string) => void = (m) => console.warn(m)
+): Promise<{ files: StaticFileEntry[]; searchDirs: string[] }> {
+  const files: StaticFileEntry[] = [];
+  const searchDirs = new Set<string>();
+  const seenOutput = new Set<string>(); // de-dup output paths across include roots
+
+  for (const inc of config.include) {
+    const root = resolvePath(inc);
+    let st: import('node:fs').Stats;
+    try {
+      st = await stat(root);
+    } catch {
+      warn(
+        `clean-jsdoc-theme: staticFiles include '${inc}' (resolved '${root}') was not found; skipping it.`
+      );
       continue;
     }
-    const content = doc.content.replace(DOC_IMAGE_RE, (full, pre, src, post) =>
-      map.has(src) ? `${pre}${map.get(src)}${post}` : full
-    );
-    out.push({ ...doc, content });
+
+    if (st.isDirectory()) {
+      searchDirs.add(root);
+      const walk = async (absDir: string): Promise<void> => {
+        let entries: import('node:fs').Dirent[];
+        try {
+          entries = await readdir(absDir, { withFileTypes: true });
+        } catch {
+          return;
+        }
+        for (const entry of entries) {
+          if (entry.name.startsWith('.')) continue;
+          const abs = joinPath(absDir, entry.name);
+          if (entry.isDirectory()) {
+            if (!STATIC_DIR_SKIP.has(entry.name)) await walk(abs);
+            continue;
+          }
+          if (!entry.isFile()) continue;
+          if (!staticFileIncluded(abs, config)) continue;
+          const outputPath = staticFileOutputName(abs, root);
+          if (seenOutput.has(outputPath)) continue;
+          let contents: Buffer;
+          try {
+            contents = await readFile(abs);
+          } catch (err) {
+            warn(
+              `clean-jsdoc-theme: could not read static file '${abs}' — ${(err as Error).message}; skipping.`
+            );
+            continue;
+          }
+          seenOutput.add(outputPath);
+          files.push({ outputPath, absSource: resolvePath(abs), contents });
+        }
+      };
+      await walk(root);
+    } else if (st.isFile()) {
+      // A file include's parent dir is the search root, so the image resolver can
+      // find it by the bare output name (its basename).
+      searchDirs.add(dirname(root));
+      if (!staticFileIncluded(root, config)) continue;
+      const outputPath = staticFileOutputName(root, root);
+      if (!seenOutput.has(outputPath)) {
+        try {
+          const contents = await readFile(root);
+          seenOutput.add(outputPath);
+          files.push({ outputPath, absSource: resolvePath(root), contents });
+        } catch (err) {
+          warn(
+            `clean-jsdoc-theme: could not read static file '${root}' — ${(err as Error).message}; skipping.`
+          );
+        }
+      }
+    }
   }
-  return { docs: out, files, inlineSvgs };
+
+  // Deterministic order so the manifest/output is stable build-to-build.
+  files.sort((a, b) => a.outputPath.localeCompare(b.outputPath));
+  return { files, searchDirs: [...searchDirs] };
 }
 
 /** The output of {@link resolveDocImages}: resolved docs + their image assets. */
@@ -1560,6 +2032,13 @@ export async function publish(data: unknown, opts: JSDocOpts, tutorials?: unknow
   // rejection; we await them at their narrated stages below.
   const docsDir =
     typeof opts.docs === 'string' && opts.docs.trim().length > 0 ? opts.docs.trim() : undefined;
+  const tutorialsDir =
+    typeof opts.tutorials === 'string' && opts.tutorials.trim().length > 0
+      ? opts.tutorials.trim()
+      : undefined;
+  // JSDoc's `templates.default.staticFiles` (verbatim passthrough + image search
+  // fallback roots). `undefined` when unset, so the whole feature is inert then.
+  const staticCfg = readStaticFilesConfig(opts);
   const pkgPromise = resolvePkg(data, opts);
   const sourcesPromise: Promise<SourceFileInput[]> = outputSourceFilesEnabled(opts)
     ? collectSourceFiles(data)
@@ -1644,8 +2123,8 @@ export async function publish(data: unknown, opts: JSDocOpts, tutorials?: unknow
 
   // README (rendered to HTML by JSDoc into `opts.readme`) → home page; the
   // tutorials resolver tree → guide pages. Both flow through setu as ordinary
-  // pages. Note: local images referenced by README/tutorial Markdown are NOT
-  // copied into the output — use absolute/served URLs for those.
+  // pages. Local images they reference (and those in JSDoc-comment prose) are
+  // routed through the `_assets/` pipeline below, like `opts.docs` images.
   const readme =
     typeof opts.readme === 'string' && opts.readme.length > 0 ? opts.readme : undefined;
   const tutorialTree = normalizeTutorials(tutorials);
@@ -1660,42 +2139,70 @@ export async function publish(data: unknown, opts: JSDocOpts, tutorials?: unknow
   // reads were started in the kickoff above (the bridge is the sanctioned I/O
   // layer; setu stays disk-free), so this stage just awaits the now-overlapped
   // work — narrated as a single step.
-  const { sources, docs, docImageFiles, inlineSvgs } = await progress.stage(
-    'Reading sources & docs',
-    async () => {
-      const [srcs, rawDocs] = await Promise.all([sourcesPromise, docsPromise]);
-      // Route the local images those docs reference through the content-hashed
-      // `_assets/` pipeline (copy + rewrite the src), so they cache-bust like the
-      // logo and custom assets. SVGs are additionally collected as inline markup
-      // so render() can drop them into the page (theme-toggle-aware) — see
-      // RenderOptions.inlineSvgs.
-      const base = docsDir
-        ? await resolveDocImages(rawDocs, docsDir)
-        : { docs: rawDocs, files: [] as OutputFile[], inlineSvgs: {} as Record<string, string> };
+  // JSDoc `templates.default.staticFiles` passthrough: collect the included
+  // files up front. Their dirs become fallback search roots for image resolution
+  // (so a bare `![x](classes-io.png)` whose file lives in a staticFiles dir still
+  // resolves + hashes), and the files themselves are copied verbatim to the
+  // output after render (covering non-image assets). Read once; `undefined` when
+  // the option is unset, so nothing changes for projects that don't use it.
+  const staticFiles = staticCfg
+    ? await progress.stage('Reading static files', () =>
+        collectStaticFiles(staticCfg, (m) => console.warn(m))
+      )
+    : undefined;
 
-      // Per-locale docs overlay (build mode): a locale's `docs.<locale>/` files
-      // win over the default docs by path; default-only docs fall back, so a
-      // partially-translated docs tree still renders the untranslated pages.
-      // Each set's images resolve against its OWN root, then merge.
-      if (!buildSpec?.docsDir) {
-        return {
-          sources: srcs,
-          docs: base.docs,
-          docImageFiles: base.files,
-          inlineSvgs: base.inlineSvgs,
-        };
-      }
-      const localeRaw = await collectDocs(buildSpec.docsDir);
-      const locale = await resolveDocImages(localeRaw, buildSpec.docsDir);
-      const merged = overlayDocs(base, locale);
-      return {
-        sources: srcs,
-        docs: merged.docs,
-        docImageFiles: merged.files,
-        inlineSvgs: merged.inlineSvgs,
-      };
+  // ONE image collector for the whole build: docs, tutorials, README, and doclet
+  // comments all route their local images through it (content-hashed `_assets/`,
+  // SVG-inlined, deduped across sources). `staticFiles.searchDirs` are the B2
+  // fallback roots. `consumed` (the source paths it copied) lets the verbatim
+  // static-file pass skip images it already served from `_assets/`.
+  const images = createImageCollector(staticFiles?.searchDirs ?? []);
+
+  const { sources, docs } = await progress.stage('Reading sources & docs', async () => {
+    const [srcs, rawDocs] = await Promise.all([sourcesPromise, docsPromise]);
+    // Route the local images those docs reference through the shared collector
+    // (copy + rewrite the src), so they cache-bust like the logo/custom assets.
+    const base = docsDir
+      ? await resolveDocImages(rawDocs, docsDir, images)
+      : { docs: rawDocs };
+
+    // Per-locale docs overlay (build mode): a locale's `docs.<locale>/` files win
+    // over the default docs by path; default-only docs fall back. Both sets'
+    // images accumulate on the shared collector; overlayDocs merges the content.
+    if (!buildSpec?.docsDir) return { sources: srcs, docs: base.docs };
+    const localeRaw = await collectDocs(buildSpec.docsDir);
+    const locale = await resolveDocImages(localeRaw, buildSpec.docsDir, images);
+    const merged = overlayDocs(
+      { docs: base.docs, files: [], inlineSvgs: {} },
+      { docs: locale.docs, files: [], inlineSvgs: {} }
+    );
+    return { sources: srcs, docs: merged.docs };
+  });
+
+  // Tutorials, the README, and JSDoc-comment (doclet) prose can all reference
+  // local images with relative paths (`![x](../img/x.png)` / `<img src>`); route
+  // them through the SAME shared collector. Tutorials resolve against the
+  // tutorials dir, the README against the project root (its usual home), and each
+  // doclet's images against its own source file's directory. Doclets are mutated
+  // IN PLACE (salty hands out live references) BEFORE `generateSite`/`stampSite`
+  // reads them.
+  const { tutorialTree: resolvedTutorials, readme: resolvedReadme } = await progress.stage(
+    'Resolving prose images',
+    async () => {
+      const tree =
+        tutorialsDir && tutorialTree.length > 0
+          ? await resolveTutorialImages(tutorialTree, tutorialsDir, images)
+          : tutorialTree;
+      const md = readme ? await rewriteImageRefs(readme, process.cwd(), images) : readme;
+      await resolveDocletImages(data, images);
+      return { tutorialTree: tree, readme: md };
     }
   );
+
+  // Every source's image assets now live on the one shared collector, deduped by
+  // served path; the inline-SVG map is keyed by rewritten src for the renderer.
+  const imageFiles = images.files;
+  const allInlineSvgs = images.inlineSvgs;
 
   const docGroups = normalizeDocGroups(opts.docGroups);
   const defaultDocGroup =
@@ -1714,8 +2221,8 @@ export async function publish(data: unknown, opts: JSDocOpts, tutorials?: unknow
 
   const siteOptions = {
     ...(pkg ? { pkg } : {}),
-    ...(readme ? { readme } : {}),
-    ...(tutorialTree.length > 0 ? { tutorials: tutorialTree } : {}),
+    ...(resolvedReadme ? { readme: resolvedReadme } : {}),
+    ...(resolvedTutorials.length > 0 ? { tutorials: resolvedTutorials } : {}),
     ...(sources.length > 0 ? { sources } : {}),
     ...(sources.length > 0 && sourceLinkToComment ? { sourceLinkToComment } : {}),
     ...(docs.length > 0 ? { docs } : {}),
@@ -1813,7 +2320,11 @@ export async function publish(data: unknown, opts: JSDocOpts, tutorials?: unknow
       },
       destination: absoluteDestination,
       islandCacheDir,
-      inlineSvgs,
+      inlineSvgs: allInlineSvgs,
+      // Emit sitemap.xml when a public site URL is configured (the protocol needs
+      // absolute URLs). In a localized build each locale's basePath yields that
+      // locale's URLs, so each locale dir gets its own sitemap.
+      ...(nonEmptyString(opts.siteUrl) ? { siteUrl: (opts.siteUrl as string).trim() } : {}),
       // Build mode: render chrome in the locale (SSR provider + island seeding)
       // and, with >1 locale, mount the language switcher.
       ...(buildSpec
@@ -1830,13 +2341,50 @@ export async function publish(data: unknown, opts: JSDocOpts, tutorials?: unknow
     })
   );
 
-  const outputFiles = [
+  const generatedFiles = [
     ...result.files,
     ...logoFiles,
     ...customAssets.files,
-    ...docImageFiles,
+    ...imageFiles,
     ...(favicon?.files ?? []),
   ];
+
+  // Static-file passthrough (A): copy each included file verbatim to its output
+  // path. Skip any file the image pipeline already consumed (it's served hashed
+  // from `_assets/`, so a root duplicate would be dead weight), and any path that
+  // would clobber a generated file or a reserved theme dir — generated output
+  // always wins; the collision is warned, never silently overwritten.
+  const staticOutputFiles: OutputFile[] = [];
+  if (staticFiles) {
+    const generatedPaths = new Set(generatedFiles.map((f) => f.path));
+    const RESERVED_PREFIXES = ['_assets/', '_islands/', 'pagefind/'];
+    let skippedConsumed = 0;
+    for (const f of staticFiles.files) {
+      if (images.consumed.has(f.absSource)) {
+        skippedConsumed++; // already hashed into `_assets/` and referenced there
+        continue;
+      }
+      if (
+        generatedPaths.has(f.outputPath) ||
+        RESERVED_PREFIXES.some((p) => f.outputPath.startsWith(p))
+      ) {
+        console.warn(
+          `clean-jsdoc-theme: static file '${f.outputPath}' would clobber generated output; skipping it.`
+        );
+        continue;
+      }
+      staticOutputFiles.push({ path: f.outputPath, contents: f.contents });
+    }
+    if (staticFiles.files.length > 0) {
+      console.log(
+        `clean-jsdoc-theme: staticFiles — copied ${staticOutputFiles.length} file(s) verbatim` +
+          (skippedConsumed > 0 ? ` (${skippedConsumed} served hashed via _assets/)` : '') +
+          '.'
+      );
+    }
+  }
+
+  const outputFiles = [...generatedFiles, ...staticOutputFiles];
   // Empty the destination first so a page removed/renamed since the last build
   // (or a stale content-hashed asset like `styles.<hash>.css`) doesn't linger in
   // the served site. Default on; opt out with `templates.default.cleanOutputDir:

--- a/packages/dwar/src/__tests__/sitemap.test.ts
+++ b/packages/dwar/src/__tests__/sitemap.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect } from 'vitest';
+import { buildSitemapXml, pageUrl } from '../sitemap';
+import { render } from '../index';
+import { makeManifest, minimalTheme } from './fixtures';
+import type { OutputFile } from '@clean-jsdoc-theme/utils';
+
+const asString = (f: OutputFile): string =>
+  typeof f.contents === 'string' ? f.contents : new TextDecoder().decode(f.contents);
+
+describe('pageUrl', () => {
+  it('renders pretty trailing-slash directory URLs; home slug → base root', () => {
+    expect(pageUrl('https://x.com', '/', '')).toBe('https://x.com/');
+    expect(pageUrl('https://x.com', '/', 'module/foo')).toBe('https://x.com/module/foo/');
+  });
+
+  it('joins basePath exactly once (sub-path deploy)', () => {
+    expect(pageUrl('https://x.com', '/docs/', '')).toBe('https://x.com/docs/');
+    expect(pageUrl('https://x.com', '/docs/', 'guides/a')).toBe('https://x.com/docs/guides/a/');
+  });
+
+  it('normalizes stray slashes on the slug', () => {
+    expect(pageUrl('https://x.com', '/', '/module/foo/')).toBe('https://x.com/module/foo/');
+  });
+});
+
+describe('buildSitemapXml', () => {
+  const slugs = ['', 'module/foo', 'guides/a'];
+
+  it('emits a valid urlset with one sorted, de-duplicated <loc> per slug', () => {
+    const xml = buildSitemapXml('https://x.com', '/', slugs)!;
+    expect(xml).toContain('<?xml version="1.0" encoding="UTF-8"?>');
+    expect(xml).toContain('<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">');
+    expect(xml).toContain('<loc>https://x.com/</loc>');
+    expect(xml).toContain('<loc>https://x.com/module/foo/</loc>');
+    expect(xml).toContain('<loc>https://x.com/guides/a/</loc>');
+    // Sorted output (guides/a before module/foo before the bare root? root '/'
+    // sorts first lexicographically).
+    const locs = [...xml.matchAll(/<loc>([^<]+)<\/loc>/g)].map((m) => m[1]);
+    expect(locs).toEqual([...locs].sort());
+    expect(xml.trim().endsWith('</urlset>')).toBe(true);
+  });
+
+  it('uses only the ORIGIN of siteUrl; basePath supplies the sub-path (no double-count)', () => {
+    // A full URL whose path already equals basePath must NOT double the sub-path.
+    const xml = buildSitemapXml('https://x.com/docs', '/docs/', ['module/foo'])!;
+    expect(xml).toContain('<loc>https://x.com/docs/module/foo/</loc>');
+    expect(xml).not.toContain('/docs/docs/');
+  });
+
+  it('de-duplicates identical URLs', () => {
+    const xml = buildSitemapXml('https://x.com', '/', ['foo', 'foo'])!;
+    expect([...xml.matchAll(/<loc>/g)]).toHaveLength(1);
+  });
+
+  it('XML-escapes the loc (query-ish chars in a slug)', () => {
+    const xml = buildSitemapXml('https://x.com', '/', ['a&b'])!;
+    expect(xml).toContain('<loc>https://x.com/a&amp;b/</loc>');
+    expect(xml).not.toContain('a&b/</loc>');
+  });
+
+  it('returns null for an unparseable or non-http(s) site URL (no broken sitemap)', () => {
+    expect(buildSitemapXml('not a url', '/', slugs)).toBeNull();
+    expect(buildSitemapXml('', '/', slugs)).toBeNull();
+    expect(buildSitemapXml('mailto:x@y.com', '/', slugs)).toBeNull();
+    expect(buildSitemapXml('ftp://x.com', '/', slugs)).toBeNull();
+  });
+
+  it('accepts an http origin and a port', () => {
+    const xml = buildSitemapXml('http://localhost:3000', '/', [''])!;
+    expect(xml).toContain('<loc>http://localhost:3000/</loc>');
+  });
+});
+
+describe('render() — sitemap.xml emission', () => {
+  it('emits sitemap.xml with the non-hidden pages when siteUrl is set', async () => {
+    const manifest = makeManifest();
+    const result = await render(manifest, { theme: minimalTheme, siteUrl: 'https://docs.example.com' });
+    const sitemap = result.files.find((f) => f.path === 'sitemap.xml');
+    expect(sitemap).toBeDefined();
+    const xml = asString(sitemap!);
+    expect(xml).toContain('<loc>https://docs.example.com/</loc>');
+    expect(xml).toContain('<loc>https://docs.example.com/guide/intro/</loc>');
+  });
+
+  it('does NOT emit sitemap.xml without siteUrl (unchanged behavior)', async () => {
+    const manifest = makeManifest();
+    const result = await render(manifest, { theme: minimalTheme });
+    expect(result.files.find((f) => f.path === 'sitemap.xml')).toBeUndefined();
+  });
+
+  it('excludes hidden pages (e.g. source-viewer pages)', async () => {
+    const manifest = makeManifest();
+    manifest.pages.push({
+      slug: 'source/secret-js',
+      frontmatter: { title: 'secret.js', kind: 'source', hidden: true },
+      body: '',
+    });
+    const result = await render(manifest, { theme: minimalTheme, siteUrl: 'https://docs.example.com' });
+    const xml = asString(result.files.find((f) => f.path === 'sitemap.xml')!);
+    expect(xml).not.toContain('source/secret-js');
+  });
+
+  it('applies basePath to the sitemap URLs', async () => {
+    const manifest = makeManifest();
+    const result = await render(manifest, {
+      theme: { ...minimalTheme, basePath: '/api/' },
+      siteUrl: 'https://example.com',
+    });
+    const xml = asString(result.files.find((f) => f.path === 'sitemap.xml')!);
+    expect(xml).toContain('<loc>https://example.com/api/</loc>');
+    expect(xml).toContain('<loc>https://example.com/api/guide/intro/</loc>');
+  });
+});

--- a/packages/dwar/src/index.ts
+++ b/packages/dwar/src/index.ts
@@ -59,6 +59,7 @@ import {
 } from './html';
 import { bundleIslands, ALL_ISLANDS } from './islands-bundle';
 import { buildCss } from './css';
+import { buildSitemapXml } from './sitemap';
 
 /**
  * Injected from package.json at build time (see tsup.config.ts `define`). The
@@ -723,6 +724,19 @@ export async function render(manifest: SiteManifest, opts: RenderOptions): Promi
   // Fuzzy-search index fetched by the cmdk island at runtime: page entries plus
   // member deep-links. (Pagefind's full-text bundle is a separate concern.)
   files.push({ path: searchIndexPath, contents: JSON.stringify([...search, ...memberEntries]) });
+
+  // sitemap.xml — one `<loc>` per non-hidden page (`search` is exactly that set:
+  // source-viewer pages are hidden, so they're excluded). Gated on `siteUrl`
+  // (the protocol needs absolute URLs); an unparseable URL yields no sitemap
+  // rather than a broken one.
+  if (opts.siteUrl) {
+    const sitemap = buildSitemapXml(
+      opts.siteUrl,
+      basePath,
+      search.map((entry) => entry.slug)
+    );
+    if (sitemap) files.push({ path: 'sitemap.xml', contents: sitemap });
+  }
 
   // Island chunks (bundled up front, before the page loop).
   let jsBytes = 0;

--- a/packages/dwar/src/sitemap.ts
+++ b/packages/dwar/src/sitemap.ts
@@ -1,0 +1,65 @@
+/**
+ * sitemap.xml generation. Pure string building — `render()` already knows every
+ * page it emits, so the sitemap is just a projection of the non-hidden page
+ * slugs onto canonical absolute URLs.
+ *
+ * The sitemap protocol requires fully-qualified `<loc>` URLs, so this needs the
+ * site's public base URL (`RenderOptions.siteUrl`). Only its ORIGIN is used; the
+ * deploy sub-path comes from `theme.basePath`, so the two never double-count —
+ * a bare origin (`https://x.com`) and a full URL whose path already equals the
+ * basePath (`https://x.com/docs`) both yield the same, correct result.
+ */
+import { withBase } from '@clean-jsdoc-theme/utils';
+
+/** XML-escape a value for safe inclusion in an element body / attribute. */
+function xmlEscape(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;');
+}
+
+/**
+ * Canonical public URL for a page `slug` under `origin` + `basePath`, in the
+ * pretty trailing-slash directory form (`module/foo` → `…/module/foo/`, the home
+ * slug `''` → `…/`). `basePath` is joined via {@link withBase}, so a sub-path
+ * deploy is reflected exactly once.
+ */
+export function pageUrl(origin: string, basePath: string, slug: string): string {
+  const clean = slug.replace(/^\/+|\/+$/g, '');
+  const pathPart = clean === '' ? '/' : `/${clean}/`;
+  return origin + withBase(basePath, pathPart);
+}
+
+/**
+ * Build a `sitemap.xml` document from page slugs, or `null` when `siteUrl` can't
+ * be parsed (so the caller emits no sitemap rather than a broken one). URLs are
+ * de-duplicated and sorted for stable, diff-friendly output. Lastmod/changefreq/
+ * priority are intentionally omitted — all optional, and a bare URL set is the
+ * cleanest valid sitemap.
+ */
+export function buildSitemapXml(
+  siteUrl: string,
+  basePath: string,
+  slugs: readonly string[]
+): string | null {
+  let origin: string;
+  try {
+    origin = new URL(siteUrl).origin;
+  } catch {
+    return null;
+  }
+  // `new URL('mailto:x').origin` and the like yield 'null'; reject non-http(s).
+  if (!origin || origin === 'null' || !/^https?:\/\//i.test(origin)) return null;
+
+  const locs = [...new Set(slugs.map((slug) => pageUrl(origin, basePath, slug)))].sort();
+  const urls = locs.map((loc) => `  <url>\n    <loc>${xmlEscape(loc)}</loc>\n  </url>`).join('\n');
+  return (
+    '<?xml version="1.0" encoding="UTF-8"?>\n' +
+    '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n' +
+    urls +
+    '\n</urlset>\n'
+  );
+}

--- a/packages/typedoc/src/__tests__/docs.test.ts
+++ b/packages/typedoc/src/__tests__/docs.test.ts
@@ -1,8 +1,13 @@
 import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { afterAll, beforeAll, describe, expect, it } from 'vitest';
-import { collectDocs, resolveDocImages } from '../docs';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import {
+  collectDocs,
+  createImageCollector,
+  resolveDocImages,
+  resolveDocletImages,
+} from '../docs';
 
 /** A 1x1 transparent PNG (bytes), enough to exercise the image asset pipeline. */
 const PNG_1X1 = Buffer.from(
@@ -86,5 +91,81 @@ describe('resolveDocImages', () => {
     const resolved = await resolveDocImages(docs, dir, noop);
     expect(resolved.docs[0].content).toBe(docs[0].content);
     expect(resolved.files).toEqual([]);
+  });
+
+  it('rewrites raw HTML <img> srcs too (both quote styles), deduped', async () => {
+    const docs = [
+      {
+        path: 'guides/x',
+        type: 'html' as const,
+        content: '<img src="./diagram.png" alt="a"><img src=\'./diagram.png\'>',
+      },
+    ];
+    const resolved = await resolveDocImages(docs, dir, noop);
+    expect(resolved.files).toHaveLength(1); // copied once
+    const m = resolved.docs[0].content.match(/\/_assets\/diagram\.[0-9a-f]{8}\.png/g);
+    expect(m).toHaveLength(2);
+    expect(resolved.docs[0].content).not.toContain('./diagram.png');
+  });
+
+  it('threads hrefForServed (basePath) into the rewritten src', async () => {
+    const docs = [
+      { path: 'guides/x', type: 'markdown' as const, content: '![d](./diagram.png)' },
+    ];
+    const resolved = await resolveDocImages(docs, dir, noop, (p) => '/docs/' + p);
+    expect(resolved.docs[0].content).toMatch(/!\[d\]\(\/docs\/_assets\/diagram\.[0-9a-f]{8}\.png\)/);
+  });
+
+  it('leaves image syntax inside code spans / fenced blocks untouched (no warn)', async () => {
+    const warn = vi.fn();
+    const docs = [
+      {
+        path: 'guides/x',
+        type: 'markdown' as const,
+        content:
+          '![real](./diagram.png)\n\n' +
+          'Inline: `![alt](./diagram.png)`\n\n' +
+          '```md\n![alt](./missing.png)\n```\n',
+      },
+    ];
+    const resolved = await resolveDocImages(docs, dir, warn);
+    // Only the real reference copied; the missing one in a fence was never read.
+    expect(resolved.files).toHaveLength(1);
+    expect(warn).not.toHaveBeenCalled();
+    expect(resolved.docs[0].content).toContain('`![alt](./diagram.png)`');
+    expect(resolved.docs[0].content).toContain('![alt](./missing.png)');
+  });
+});
+
+describe('resolveDocletImages', () => {
+  it('rewrites <img> in a doclet description relative to its source file, in place', async () => {
+    // TypeDoc's comment pipeline has already rendered `![d](./diagram.png)` to
+    // HTML; the src is relative to the symbol's own source file (meta.path).
+    const doclet = {
+      longname: 'Foo',
+      description: '<p>Hi</p><img src="./diagram.png" alt="d">',
+      params: [{ name: 'x', description: '<img src="./diagram.png" alt="p">' }],
+      meta: { path: join(dir, 'guides'), filename: 'foo.ts', lineno: 1 },
+    };
+    const collector = createImageCollector(noop);
+    await resolveDocletImages([doclet] as never, collector);
+    expect(collector.files).toHaveLength(1); // description + param share the image
+    expect(collector.files[0].path).toMatch(/^_assets\/diagram\.[0-9a-f]{8}\.png$/);
+    expect(doclet.description).toMatch(/src="\/_assets\/diagram\.[0-9a-f]{8}\.png"/);
+    expect(doclet.params[0].description).toMatch(/src="\/_assets\/diagram\.[0-9a-f]{8}\.png"/);
+  });
+
+  it('skips meta/examples and doclets without meta.path', async () => {
+    const noMeta = { longname: 'Bar', description: '<img src="./diagram.png">' };
+    const codeOnly = {
+      longname: 'Baz',
+      examples: ['<img src="./diagram.png">'],
+      meta: { path: join(dir, 'guides'), filename: 'baz.ts', lineno: 1 },
+    };
+    const collector = createImageCollector(noop);
+    await resolveDocletImages([noMeta, codeOnly] as never, collector);
+    expect(collector.files).toHaveLength(0);
+    expect(noMeta.description).toContain('./diagram.png'); // untouched (no meta.path)
+    expect(codeOnly.examples[0]).toContain('./diagram.png'); // examples skipped
   });
 });

--- a/packages/typedoc/src/docs.ts
+++ b/packages/typedoc/src/docs.ts
@@ -1,15 +1,19 @@
 /**
- * Prose-docs collection for the TypeDoc bridge — the `cleanJsdocTheme.docs`
- * directory front-end.
+ * Prose-docs collection + local-image asset pipeline for the TypeDoc bridge —
+ * the `cleanJsdocTheme.docs` directory front-end, plus the shared image resolver
+ * the README and symbol-comment prose also flow through.
  *
- * This is the TypeDoc twin of the JSDoc bridge's `collectDocs` / `resolveDocImages`
- * (in `clean-jsdoc-theme/src/publish.ts`). Per the repo convention, the two
- * bridges are independent leaf packages: pure helpers are COPIED, never
- * cross-imported. The only behavioural difference is that warnings go through a
- * `warn` callback (TypeDoc's `logger.warn`) rather than `console.warn`.
+ * This is the TypeDoc twin of the JSDoc bridge's `collectDocs` /
+ * `resolveDocImages` / `resolveDocletImages` (in `clean-jsdoc-theme/src/publish.ts`).
+ * Per the repo convention, the two bridges are independent leaf packages: pure
+ * helpers are COPIED, never cross-imported. The only behavioural differences are
+ * that warnings go through a `warn` callback (TypeDoc's `logger.warn`) rather than
+ * `console.warn`, and every served href is threaded through `hrefForServed` for
+ * sub-directory (`basePath`) deploys.
  *
- * The bridge is the I/O layer here — it walks the docs tree and routes referenced
- * images through `_assets/` — so setu/dwar only ever see in-memory `DocInput`s and
+ * The bridge is the I/O layer here — it walks the docs tree and routes every
+ * referenced local image (Markdown `![](src)` AND raw `<img src>`) through
+ * `_assets/` — so setu/dwar only ever see in-memory `DocInput`s / doclets and
  * already-rewritten `/_assets/…` srcs, and `dwar.render()` stays pure.
  */
 import { createHash } from 'node:crypto';
@@ -17,6 +21,7 @@ import { readdir, readFile } from 'node:fs/promises';
 import { basename, dirname, extname, join as joinPath, resolve as resolvePath } from 'node:path';
 import type { DocInput } from '@clean-jsdoc-theme/setu';
 import type { OutputFile } from '@clean-jsdoc-theme/dwar';
+import type { TDoclet } from '@clean-jsdoc-theme/utils';
 
 /** Sink for non-fatal warnings (TypeDoc's `logger.warn`). */
 type Warn = (message: string) => void;
@@ -119,42 +124,54 @@ export interface ResolvedDocs {
 const DOC_IMAGE_RE = /(!\[[^\]]*\]\()([^)\s]+)((?:\s+"[^"]*")?\))/g;
 
 /**
- * Resolve the local images a doc references and route them through the same
- * content-hashed `_assets/` pipeline as the JSDoc bridge. For each `![alt](src)`
- * whose `src` points to a file on disk, the file is copied to
- * `_assets/<base>.<hash><ext>` (cache-busted, deduped across docs) and the `src`
- * is rewritten to the root-relative `/_assets/<base>.<hash><ext>`. A `src` is
- * resolved relative to the project root when it starts with `/`, else relative to
- * the doc's own directory; absolute (`http(s):`, `data:`), `#`-anchor, and
- * unreadable srcs are left untouched (the last with a warning). SVGs are ALSO
- * collected as inline markup (keyed by the rewritten src) so the renderer can drop
- * them into the page — its `[data-theme="dark"]` styles then follow the toggle.
+ * HTML image: captures the `<img …src=` prefix (through the opening quote), the
+ * quote char, the src value, and the closing quote (a backreference to the
+ * opener). TypeDoc's comment pipeline renders `![alt](src)` to `<img src="…">`,
+ * and prose can embed raw `<img>`; this matches both quote styles wherever `src`
+ * sits in the tag.
  */
-export async function resolveDocImages(
-  docs: DocInput[],
-  docsDir: string,
+const HTML_IMAGE_RE = /(<img\b[^>]*?\bsrc\s*=\s*(["']))([^"']*)(\2)/gi;
+
+/**
+ * A reusable local-image asset pipeline shared by every prose source (docs,
+ * README, symbol comments). `resolve(src, baseDir)` copies a local image to
+ * `_assets/<base>.<hash><ext>` (content-hashed → cache-busted, deduped across all
+ * sources via the shared caches) and returns the served href (via
+ * `hrefForServed`). It accumulates each copied file on `files` and each SVG's
+ * markup on `inlineSvgs` (keyed by the rewritten href, so the renderer can inline
+ * it — its `[data-theme]` styles then track the toggle). A `src` is resolved
+ * relative to the project root when it starts with `/`, else relative to
+ * `baseDir`; absolute (`http(s):`, `data:`), `#`-anchor, and unreadable srcs yield
+ * `null` (the last warned) so callers leave them untouched. The JSDoc twin is
+ * `createImageCollector` in `clean-jsdoc-theme/src/publish.ts`.
+ */
+export interface ImageCollector {
+  resolve(rawSrc: string, baseDir: string): Promise<string | null>;
+  readonly files: OutputFile[];
+  readonly inlineSvgs: Record<string, string>;
+}
+
+export function createImageCollector(
   warn: Warn,
   hrefForServed: (servedPath: string) => string = (p) => '/' + p
-): Promise<ResolvedDocs> {
-  if (docs.length === 0) return { docs, files: [], inlineSvgs: {} };
-  const root = resolvePath(docsDir);
+): ImageCollector {
   const files: OutputFile[] = [];
-  const seenServed = new Set<string>();
   const inlineSvgs: Record<string, string> = {};
-  // abs path → rewritten src (root-relative `/_assets/…`), or null if unreadable.
+  const seenServed = new Set<string>();
+  // abs path → rewritten src (served `/_assets/…` href), or null if unreadable.
   const cache = new Map<string, string | null>();
 
-  const resolveOne = async (rawSrc: string, docDir: string): Promise<string | null> => {
+  const resolve = async (rawSrc: string, baseDir: string): Promise<string | null> => {
     const src = rawSrc.trim();
     if (!src || isServableUrl(src) || src.startsWith('#') || src.startsWith('data:')) return null;
-    const abs = src.startsWith('/') ? resolvePath(src.slice(1)) : resolvePath(docDir, src);
+    const abs = src.startsWith('/') ? resolvePath(src.slice(1)) : resolvePath(baseDir, src);
     if (cache.has(abs)) return cache.get(abs) ?? null;
     let bytes: Buffer;
     try {
       bytes = await readFile(abs);
     } catch {
       warn(
-        `[clean-jsdoc-theme] could not read doc image '${src}' (resolved '${abs}'); leaving it as-is.`
+        `[clean-jsdoc-theme] could not read image '${src}' (resolved '${abs}'); leaving it as-is.`
       );
       cache.set(abs, null);
       return null;
@@ -175,24 +192,163 @@ export async function resolveDocImages(
     return href;
   };
 
+  return { resolve, files, inlineSvgs };
+}
+
+/**
+ * Char ranges of Markdown/HTML **code** regions — fenced blocks (` ``` `/`~~~`),
+ * HTML `<pre>`/`<code>`, and inline backtick spans. Image references inside these
+ * are literal example syntax an author is *documenting*, not real images, so the
+ * rewriter skips them. Mirrors the JSDoc bridge's `CODE_REGION_RE`.
+ */
+const CODE_REGION_RE =
+  /```[\s\S]*?```|~~~[\s\S]*?~~~|<pre[\s\S]*?<\/pre>|<code[^>]*>[\s\S]*?<\/code>|`[^`\n]+`/gi;
+
+/** Collect the [start, end) char ranges of code regions in `content`. */
+function codeRanges(content: string): Array<[number, number]> {
+  const ranges: Array<[number, number]> = [];
+  for (const m of content.matchAll(CODE_REGION_RE)) {
+    if (m.index !== undefined) ranges.push([m.index, m.index + m[0].length]);
+  }
+  return ranges;
+}
+
+/** Whether char offset `idx` falls inside any code range. */
+function indexInCode(idx: number, ranges: ReadonlyArray<[number, number]>): boolean {
+  for (const [s, e] of ranges) if (idx >= s && idx < e) return true;
+  return false;
+}
+
+/**
+ * Rewrite the local image references in `content` to their served `_assets/…`
+ * paths, routing each through `collector`. Handles BOTH Markdown `![alt](src)`
+ * and raw HTML `<img src="…">` (TypeDoc renders comment images to the latter), so
+ * prose in either form is covered. Relative srcs resolve against `baseDir`,
+ * `/`-rooted srcs against the project root, and external/`data:`/anchor srcs are
+ * left untouched — as is image syntax inside a code span / fenced block (example
+ * syntax, not a real image). Returns the original string unchanged when nothing
+ * was rewritten.
+ */
+export async function rewriteImageRefs(
+  content: string,
+  baseDir: string,
+  collector: ImageCollector
+): Promise<string> {
+  if (!content) return content;
+  const ranges = codeRanges(content);
+  const map = new Map<string, string>();
+  const collect = async (re: RegExp, srcGroup: number): Promise<void> => {
+    for (const m of content.matchAll(re)) {
+      if (m.index !== undefined && indexInCode(m.index, ranges)) continue; // example syntax
+      const src = m[srcGroup];
+      if (map.has(src)) continue;
+      const href = await collector.resolve(src, baseDir);
+      if (href) map.set(src, href);
+    }
+  };
+  await collect(DOC_IMAGE_RE, 2);
+  await collect(HTML_IMAGE_RE, 3);
+  if (map.size === 0) return content;
+  return content
+    .replace(DOC_IMAGE_RE, (full, pre, src, post, offset: number) =>
+      !indexInCode(offset, ranges) && map.has(src) ? `${pre}${map.get(src)}${post}` : full
+    )
+    .replace(HTML_IMAGE_RE, (full, pre, _quote, src, close, offset: number) =>
+      !indexInCode(offset, ranges) && map.has(src) ? `${pre}${map.get(src)}${close}` : full
+    );
+}
+
+/**
+ * Resolve the local images a doc references and route them through the shared
+ * content-hashed `_assets/` pipeline (see {@link createImageCollector}). Each
+ * `![alt](src)` / `<img src>` whose `src` points to a file on disk is copied and
+ * its `src` rewritten to the served `_assets/<base>.<hash><ext>`, resolved
+ * relative to the project root when it starts with `/`, else relative to the
+ * doc's own directory. SVGs are also collected for inlining (theme-toggle-aware).
+ */
+export async function resolveDocImages(
+  docs: DocInput[],
+  docsDir: string,
+  warn: Warn,
+  hrefForServed: (servedPath: string) => string = (p) => '/' + p
+): Promise<ResolvedDocs> {
+  if (docs.length === 0) return { docs, files: [], inlineSvgs: {} };
+  const root = resolvePath(docsDir);
+  const collector = createImageCollector(warn, hrefForServed);
   const out: DocInput[] = [];
   for (const doc of docs) {
     const docDir = dirname(resolvePath(root, doc.path));
-    const map = new Map<string, string>();
-    for (const m of doc.content.matchAll(DOC_IMAGE_RE)) {
-      const src = m[2];
-      if (map.has(src)) continue;
-      const href = await resolveOne(src, docDir);
-      if (href) map.set(src, href);
-    }
-    if (map.size === 0) {
-      out.push(doc);
-      continue;
-    }
-    const content = doc.content.replace(DOC_IMAGE_RE, (full, pre, src, post) =>
-      map.has(src) ? `${pre}${map.get(src)}${post}` : full
-    );
-    out.push({ ...doc, content });
+    const content = await rewriteImageRefs(doc.content, docDir, collector);
+    out.push(content === doc.content ? doc : { ...doc, content });
   }
-  return { docs: out, files, inlineSvgs };
+  return { docs: out, files: collector.files, inlineSvgs: collector.inlineSvgs };
+}
+
+/**
+ * Doclet keys whose string values are raw source/code/meta, NOT rendered prose —
+ * never scanned for images (a stray `<img`/`![` there must not be rewritten).
+ */
+const DOCLET_IMAGE_SKIP_KEYS = new Set(['meta', 'comment', 'examples', 'tags']);
+
+/**
+ * Recursively rewrite the `<img>`/`![]()` image srcs in every prose string
+ * reachable from a doclet object, resolving against `baseDir`. Only strings that
+ * actually carry an image marker (`<img` or `![`) are touched — a cheap guard so
+ * names/identifiers/code are never scanned — and raw/code keys
+ * ({@link DOCLET_IMAGE_SKIP_KEYS}) are skipped. Recurses into nested
+ * objects/arrays (e.g. `params[].description`). Mutates `node` in place.
+ */
+async function rewriteDocletStrings(
+  node: Record<string, unknown>,
+  baseDir: string,
+  collector: ImageCollector
+): Promise<void> {
+  for (const [key, value] of Object.entries(node)) {
+    if (DOCLET_IMAGE_SKIP_KEYS.has(key)) continue;
+    if (typeof value === 'string') {
+      if (value.includes('<img') || value.includes('![')) {
+        const rewritten = await rewriteImageRefs(value, baseDir, collector);
+        if (rewritten !== value) node[key] = rewritten;
+      }
+    } else if (Array.isArray(value)) {
+      for (let i = 0; i < value.length; i++) {
+        const item = value[i];
+        if (typeof item === 'string') {
+          if (item.includes('<img') || item.includes('![')) {
+            const rewritten = await rewriteImageRefs(item, baseDir, collector);
+            if (rewritten !== item) value[i] = rewritten;
+          }
+        } else if (item && typeof item === 'object') {
+          await rewriteDocletStrings(item as Record<string, unknown>, baseDir, collector);
+        }
+      }
+    } else if (value && typeof value === 'object') {
+      await rewriteDocletStrings(value as Record<string, unknown>, baseDir, collector);
+    }
+  }
+}
+
+/**
+ * Resolve the local images referenced inside symbol-comment prose (doclet
+ * descriptions / `classdesc` / nested param/property/returns/type-param
+ * descriptions) and route them through the shared `collector`. The TypeDoc
+ * comment pipeline has already rendered a comment's `![alt](../img/x.png)` to an
+ * HTML `<img src="../img/x.png">` by the time the doclets are built, so each src
+ * is resolved **relative to that symbol's own source file** (`meta.path` — the
+ * directory `reflectionsToDoclets` recorded from `reflection.sources[0]`). The
+ * doclets are a bridge-owned in-memory array, so they're mutated IN PLACE before
+ * `generateSite` reads them. Resilient — a doclet without `meta.path` (no source
+ * coords) is skipped; an unreadable image is warned + left as-is. The JSDoc twin
+ * is `resolveDocletImages` in `clean-jsdoc-theme/src/publish.ts`.
+ */
+export async function resolveDocletImages(
+  doclets: readonly TDoclet[],
+  collector: ImageCollector
+): Promise<void> {
+  for (const d of doclets) {
+    if (!d || typeof d !== 'object') continue;
+    const path = d.meta?.path;
+    if (typeof path !== 'string' || path.length === 0) continue;
+    await rewriteDocletStrings(d as unknown as Record<string, unknown>, path, collector);
+  }
 }

--- a/packages/typedoc/src/options.ts
+++ b/packages/typedoc/src/options.ts
@@ -76,6 +76,12 @@ export interface CleanJsdocThemeBlock {
    * full URL (its pathname is used); defaults to `"/"`.
    */
   basePath?: unknown;
+  /**
+   * Site public base URL (e.g. `"https://example.com"`). When set, the build
+   * emits a `sitemap.xml` listing every non-hidden page's canonical URL. Only the
+   * origin is used; the deploy sub-path comes from `basePath`.
+   */
+  siteUrl?: unknown;
   /** Escalate validation errors (bad font / unknown key) to a hard failure. */
   strict?: unknown;
   [key: string]: unknown;
@@ -94,7 +100,7 @@ export function declareThemeOption(app: Application): void {
     help:
       'clean-jsdoc-theme options (siteName, fonts, sectionOrder, docs, docGroups, ' +
       'defaultDocGroup, menu, clubSidebarItems, copyPage, pageNav, playground, ' +
-      'aiPrompt, footer, favicon, meta, basePath, strict).',
+      'aiPrompt, footer, favicon, meta, basePath, siteUrl, strict).',
     type: ParameterType.Object,
     defaultValue: {},
   };

--- a/packages/typedoc/src/write-site.ts
+++ b/packages/typedoc/src/write-site.ts
@@ -49,7 +49,13 @@ import {
 import type { FontSet, PlaygroundProvider, TDoclet, ValidatedFonts } from '@clean-jsdoc-theme/utils';
 import { reflectionsToDoclets } from './reflection-to-doclets';
 import { markdownToHtml, partsToMarkdown } from './comment';
-import { collectDocs, resolveDocImages } from './docs';
+import {
+  collectDocs,
+  createImageCollector,
+  resolveDocImages,
+  resolveDocletImages,
+  rewriteImageRefs,
+} from './docs';
 import { writeOutputFiles } from './write-output-files';
 import { KNOWN_NON_THEME_KEYS, readThemeOption } from './options';
 import type { CleanJsdocThemeBlock } from './options';
@@ -628,22 +634,33 @@ export async function writeSite(
     logger.info(formatted);
   }
 
-  // Adapt → flat doclets → salty collection (the same shape setu consumes from
-  // the JSDoc path).
-  const doclets = reflectionsToDoclets(project, logger);
-  const collection = salty.taffy(doclets);
-
-  const readme = renderReadme(project);
-  const pkg = await resolvePkg(project);
-  const sources = await collectSourceFiles(doclets, logger);
-
   // Site root prefix so the output can be served from a sub-directory. Bad/empty
   // input fails safe to '/' (the default), so an unset option is byte-identical.
-  // Every served asset href (logos, favicon, doc images) is prefixed through
-  // `hrefForServed`, exactly like the JSDoc bridge — in-content links (pages,
-  // source) are prefixed downstream by dwar from `theme.basePath`.
+  // Every served asset href (logos, favicon, doc/comment images) is prefixed
+  // through `hrefForServed`, exactly like the JSDoc bridge — in-content links
+  // (pages, source) are prefixed downstream by dwar from `theme.basePath`.
   const basePath = normalizeBasePath(block.basePath);
   const hrefForServed = (servedPath: string): string => withBase(basePath, '/' + servedPath);
+  const warn = (msg: string): void => logger.warn(msg);
+
+  // Adapt → flat doclets. The README and symbol-comment prose can reference local
+  // images with relative paths (`![x](../img/x.png)` / `<img src>`); route them
+  // through the SAME content-hashed `_assets/` pipeline as `cleanJsdocTheme.docs`.
+  // Comment images resolve against each symbol's own source file (`meta.path`),
+  // the README against the project root (its usual home). The doclets are a
+  // bridge-owned array, so `resolveDocletImages` mutates them IN PLACE before
+  // `generateSite` reads them; one shared collector dedupes a shared image.
+  const doclets = reflectionsToDoclets(project, logger);
+  const proseImages = createImageCollector(warn, hrefForServed);
+  await resolveDocletImages(doclets, proseImages);
+  const collection = salty.taffy(doclets);
+
+  // The README's source dir isn't carried on the parts, so resolve its images
+  // against the project root, where a README almost always lives.
+  const rawReadme = renderReadme(project);
+  const readme = rawReadme ? await rewriteImageRefs(rawReadme, process.cwd(), proseImages) : rawReadme;
+  const pkg = await resolvePkg(project);
+  const sources = await collectSourceFiles(doclets, logger);
 
   // Prose docs (`cleanJsdocTheme.docs` directory) → pages at clean slugs, with
   // their local images routed through the `_assets/` pipeline (the bridge is the
@@ -651,11 +668,20 @@ export async function writeSite(
   // sidebar sections; `defaultDocGroup` labels docs with no group of their own.
   const docsDir =
     typeof block.docs === 'string' && block.docs.trim().length > 0 ? block.docs.trim() : undefined;
-  const warn = (msg: string): void => logger.warn(msg);
   const resolvedDocs = docsDir
     ? await resolveDocImages(await collectDocs(docsDir, warn), docsDir, warn, hrefForServed)
     : { docs: [] as DocInput[], files: [] as OutputFile[], inlineSvgs: {} as Record<string, string> };
   const docs = resolvedDocs.docs;
+
+  // Merge every source's image assets, deduped by served path (identical bytes →
+  // identical content-hashed name, so a shared image is written once), and union
+  // the inline-SVG maps the renderer substitutes by src.
+  const imageFiles = (() => {
+    const byPath = new Map<string, OutputFile>();
+    for (const f of [...resolvedDocs.files, ...proseImages.files]) byPath.set(f.path, f);
+    return [...byPath.values()];
+  })();
+  const inlineSvgs = { ...resolvedDocs.inlineSvgs, ...proseImages.inlineSvgs };
   const docGroups = normalizeSectionOrder(block.docGroups);
   const defaultDocGroup =
     typeof block.defaultDocGroup === 'string' && block.defaultDocGroup.trim().length > 0
@@ -746,10 +772,13 @@ export async function writeSite(
     },
     destination,
     islandCacheDir,
-    // SVGs referenced by docs are inlined (theme-toggle-aware) rather than
-    // `<img>`-ed; an empty map is a no-op, so a docs-less build is unaffected.
-    ...(Object.keys(resolvedDocs.inlineSvgs).length > 0
-      ? { inlineSvgs: resolvedDocs.inlineSvgs }
+    // SVGs referenced by docs/README/comments are inlined (theme-toggle-aware)
+    // rather than `<img>`-ed; an empty map is a no-op, so an image-less build is
+    // unaffected.
+    ...(Object.keys(inlineSvgs).length > 0 ? { inlineSvgs } : {}),
+    // Emit sitemap.xml when a public site URL is configured (needs absolute URLs).
+    ...(typeof block.siteUrl === 'string' && block.siteUrl.trim().length > 0
+      ? { siteUrl: block.siteUrl.trim() }
       : {}),
   });
 
@@ -757,7 +786,7 @@ export async function writeSite(
     ...result.files,
     ...logoFiles,
     ...(favicon?.files ?? []),
-    ...resolvedDocs.files,
+    ...imageFiles,
   ];
   // TypeDoc cleans only its own `out` (the default html output), never a custom
   // `outputs` path — so without this, a page removed or renamed between builds

--- a/packages/utils/src/config/opts-schema.ts
+++ b/packages/utils/src/config/opts-schema.ts
@@ -207,6 +207,7 @@ export const THEME_OPT_KEYS = [
   'clubSidebarItems',
   'aiPrompt',
   'basePath',
+  'siteUrl',
   'favicon',
   'footer',
   'meta',

--- a/packages/utils/src/site/render.ts
+++ b/packages/utils/src/site/render.ts
@@ -133,6 +133,15 @@ export interface RenderOptions {
    * output stays byte-identical.
    */
   locale?: RenderLocale;
+  /**
+   * The site's public base URL (e.g. `https://example.com` or
+   * `https://example.com/docs`). When set, dwar emits a `sitemap.xml` at the
+   * output root listing every non-hidden page's canonical URL. Only the URL's
+   * **origin** is used — the deploy sub-path comes from `theme.basePath`, so the
+   * two never double-count (a bare origin works, and so does a full URL whose
+   * path equals basePath). Omit it and no sitemap is emitted (today's behavior).
+   */
+  siteUrl?: string;
 }
 
 /** Active-locale chrome translations for a localized render. See {@link RenderOptions.locale}. */


### PR DESCRIPTION
Fixes #333.

## Summary

Local image assets now work from **every prose source the theme renders**, not just `opts.docs` — plus JSDoc `staticFiles` support and a generated `sitemap.xml`. Both the JSDoc and TypeDoc bridges have parity.

### Image resolution
- Images referenced from **tutorials, the README, and JSDoc / TypeScript doc comments** are copied through the content-hashed `_assets/` pipeline and the reference is rewritten — both Markdown `![](…)` and raw `<img>`. Comment images resolve against each symbol's own source file; SVGs are inlined (theme-toggle-aware).
- **`templates.default.staticFiles`** is honored: included files are copied verbatim to the output root (JSDoc parity), and the include directories become fallback search roots, so a bare reference like `![](classes-io.png)` resolves and is hashed — no need to rewrite existing comments/tutorials. A file already served from `_assets/` isn't duplicated at the root.
- Image syntax shown **inside code spans / fenced blocks / `<pre>`/`<code>`** is left literal — no spurious copy, rewrite, or "could not read image" warning.

### sitemap.xml
- Set `siteUrl` and the build emits `sitemap.xml` at the output root — one `<loc>` per non-hidden page (hidden source-viewer pages excluded). Only the URL's origin is used; the deploy sub-path comes from `basePath`, so the two never double-count.

### Docs & examples
- New **"Working with Images"** guide (en + hi/ja/zh) covering all of the above.
- `siteUrl` documented on the configuration page in every locale; enabled on the docs-site itself.
- `examples/basic` and `examples/typedoc-basic` gain fixtures exercising each path.
- `ARCHITECTURE.md` updated for the image pipeline, `staticFiles`, sitemap, and the code-region skip.

## Tests
- utils **116**, dwar **138**, clean-jsdoc-theme **78**, typedoc **50** — all green; typecheck + lint clean.
- Verified end-to-end against `examples/basic`, `examples/typedoc-basic`, the docs-site (all locales build with **zero** image warnings), and a real consumer project.

## Commits
1. `feat(dwar)` — emit sitemap.xml from the rendered page set
2. `feat(clean-jsdoc-theme)` — resolve images from tutorials / README / comments, staticFiles, code-region skip
3. `feat(typedoc)` — image-resolution parity + siteUrl
4. `test(examples)` — image, staticFiles, and siteUrl fixtures
5. `docs` — Working with Images guide, siteUrl docs, ARCHITECTURE
